### PR TITLE
Remove from sparse match kokkos

### DIFF
--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -21,6 +21,13 @@ using intKokkosView = Kokkos::View<int *, Kokkos::DefaultExecutionSpace>;
 using boolKokkosView = Kokkos::View<bool *, Kokkos::DefaultExecutionSpace>;
 using ConstMatRowMapKokkosView = KokkosCsrGraph::row_map_type::const_type;
 
+// Create views using scratch memory space
+using ScratchSpace = typename KokkosTeamMemberType::scratch_memory_space;
+using ScratchIntView = Kokkos::View<PetscInt*, ScratchSpace, Kokkos::MemoryUnmanaged>;
+using ScratchScalarView = Kokkos::View<PetscScalar*, ScratchSpace, Kokkos::MemoryUnmanaged>;
+using Scratch2DIntView = Kokkos::View<PetscInt**, ScratchSpace, Kokkos::MemoryUnmanaged>;
+using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::MemoryUnmanaged>;
+
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 
 #endif

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -57,7 +57,7 @@ module air_mg_setup
          temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_A_DROP)
          if (.NOT. PetscObjectIsNull(temp_mat)) then
 
-            call remove_from_sparse_match_no_lump(input_mat, air_data%reuse(our_level)%reuse_mat(MAT_A_DROP))     
+            call remove_from_sparse_match(input_mat, air_data%reuse(our_level)%reuse_mat(MAT_A_DROP))     
 
          else
          
@@ -528,7 +528,7 @@ module air_mg_setup
             temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_W_DROP)
             if (.NOT. PetscObjectIsNull(temp_mat)) then
    
-               call remove_from_sparse_match_no_lump(air_data%reuse(our_level)%reuse_mat(MAT_W), &
+               call remove_from_sparse_match(air_data%reuse(our_level)%reuse_mat(MAT_W), &
                         air_data%reuse(our_level)%reuse_mat(MAT_W_DROP))  
                
             ! First time so just drop according to a tolerance 
@@ -773,7 +773,7 @@ module air_mg_setup
       temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_Z_DROP)
       if (.NOT. PetscObjectIsNull(temp_mat)) then
 
-         call remove_from_sparse_match_no_lump(air_data%reuse(our_level)%reuse_mat(MAT_Z), &
+         call remove_from_sparse_match(air_data%reuse(our_level)%reuse_mat(MAT_Z), &
                   air_data%reuse(our_level)%reuse_mat(MAT_Z_DROP))     
          
       ! First time so just drop according to a tolerance 
@@ -966,8 +966,12 @@ module air_mg_setup
       temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_RAP_DROP)
       if (.NOT. PetscObjectIsNull(temp_mat)) then
 
+         ! Duplicate the sparsity
+         call MatDuplicate(air_data%reuse(our_level)%reuse_mat(MAT_RAP_DROP), &
+                  MAT_DO_NOT_COPY_VALUES, coarse_matrix, ierr)
+
          call remove_from_sparse_match(air_data%reuse(our_level)%reuse_mat(MAT_RAP), &
-                  air_data%reuse(our_level)%reuse_mat(MAT_RAP_DROP), coarse_matrix, &
+                  coarse_matrix, &
                   lump=air_data%options%a_lump)
 
       ! First time so just drop according to a tolerance 

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -231,6 +231,18 @@ module c_petsc_interfaces
 
    interface   
       
+      subroutine remove_from_sparse_match_kokkos(A_array, B_array, lump_int) &
+         bind(c, name="remove_from_sparse_match_kokkos")
+         use iso_c_binding
+         integer(c_long_long) :: A_array
+         integer(c_long_long) :: B_array
+         integer(c_int), value :: lump_int
+      end subroutine remove_from_sparse_match_kokkos         
+ 
+   end interface   
+
+   interface   
+      
       subroutine MatSetAllValues_kokkos(A_array, val) &
          bind(c, name="MatSetAllValues_kokkos")
          use iso_c_binding

--- a/src/Gmres_Polyk.kokkos.cxx
+++ b/src/Gmres_Polyk.kokkos.cxx
@@ -4,13 +4,6 @@
 #include <../src/mat/impls/aij/seq/aij.h>
 #include <../src/mat/impls/aij/mpi/mpiaij.h>
 
-// Create views using scratch memory space
-using ScratchSpace = typename KokkosTeamMemberType::scratch_memory_space;
-using ScratchIntView = Kokkos::View<PetscInt*, ScratchSpace, Kokkos::MemoryUnmanaged>;
-using ScratchScalarView = Kokkos::View<PetscScalar*, ScratchSpace, Kokkos::MemoryUnmanaged>;
-using Scratch2DIntView = Kokkos::View<PetscInt**, ScratchSpace, Kokkos::MemoryUnmanaged>;
-using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::MemoryUnmanaged>;
-
 //------------------------------------------------------------------------------------------------------------------------
 
 // Compute matrix-matrix product with fixed order sparsity but with kokkos - keeping everything on the device
@@ -312,7 +305,7 @@ PETSC_INTERN void mat_mult_powers_share_sparsity_kokkos(Mat *input_mat, int poly
          PetscInt target_end = device_submat_i[row_idx + 1];
          PetscInt target_ncols = target_end - target_start;
 
-         // We'll perform a binary search to find matching indices
+         // We'll perform a search to find matching indices
          // We're matching indices in sparsity mat to those in submat
          // This is just an intersection between row i and the row of column j
          // This assumes column indices are already sorted 

--- a/src/PETSc_Helper.F90
+++ b/src/PETSc_Helper.F90
@@ -125,7 +125,7 @@ logical, protected :: kokkos_debug_global = .FALSE.
 
             call MatAXPY(temp_mat, -1d0, output_mat, DIFFERENT_NONZERO_PATTERN, ierr)
             call MatNorm(temp_mat, NORM_FROBENIUS, normy, ierr)
-            if (normy .gt. 1d-13) then
+            if (normy .gt. 1d-12) then
                !call MatFilter(temp_mat, 1d-14, PETSC_TRUE, PETSC_FALSE, ierr)
                !call MatView(temp_mat, PETSC_VIEWER_STDOUT_WORLD, ierr)
                print *, "Kokkos and CPU versions of remove_small_from_sparse do not match"

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -706,6 +706,313 @@ PETSC_INTERN void remove_small_from_sparse_kokkos(Mat *input_mat, PetscReal tol,
    return;
 }
 
+
+//------------------------------------------------------------------------------------------------------------------------
+
+// Drop according to a existing sparsity in output_mat but with kokkos - keeping everything on the device
+PETSC_INTERN void remove_from_sparse_match_kokkos(Mat *input_mat, Mat *output_mat, int lump_int)
+{
+
+   MPI_Comm MPI_COMM_MATRIX;
+   PetscInt local_rows, local_cols, global_rows, global_cols;
+   PetscInt global_row_start, global_row_end_plus_one;
+   PetscInt global_col_start, global_col_end_plus_one;
+   PetscInt rows_ao_input, cols_ao_input, rows_ao_output, cols_ao_output;
+   MatType mat_type;
+
+   MatGetType(*input_mat, &mat_type);
+   // Are we in parallel?
+   bool mpi = strcmp(mat_type, MATMPIAIJKOKKOS) == 0;
+
+   // Get the comm
+   PetscObjectGetComm((PetscObject)*input_mat, &MPI_COMM_MATRIX);
+   MatGetLocalSize(*input_mat, &local_rows, &local_cols);
+   MatGetSize(*input_mat, &global_rows, &global_cols);
+   // This returns the global index of the local portion of the matrix
+   MatGetOwnershipRange(*input_mat, &global_row_start, &global_row_end_plus_one);
+   MatGetOwnershipRangeColumn(*input_mat, &global_col_start, &global_col_end_plus_one);      
+
+   Mat_MPIAIJ *mat_mpi = nullptr;
+   Mat mat_local, mat_nonlocal;
+   Mat_MPIAIJ *mat_mpi_output = nullptr;
+   Mat mat_local_output, mat_nonlocal_output;   
+
+   PetscIntKokkosViewHost colmap_input_h, colmap_output_h;
+   PetscIntKokkosView colmap_input_d, colmap_output_d;   
+   if (mpi)
+   {
+      mat_mpi = (Mat_MPIAIJ *)(*input_mat)->data;
+      mat_local = mat_mpi->A;
+      mat_nonlocal = mat_mpi->B;
+      MatGetSize(mat_nonlocal, &rows_ao_input, &cols_ao_input); 
+
+      // We also copy the input mat colmap over to the device as we need it
+      colmap_input_h = PetscIntKokkosViewHost(mat_mpi->garray, cols_ao_input);
+      colmap_input_d = PetscIntKokkosView("colmap_input_d", cols_ao_input);
+      Kokkos::deep_copy(colmap_input_d, colmap_input_h);  
+
+      // Log copy with petsc
+      size_t bytes = colmap_input_h.extent(0) * sizeof(PetscInt);
+      PetscLogCpuToGpu(bytes);
+      
+      // Same for output
+      mat_mpi_output = (Mat_MPIAIJ *)(*output_mat)->data;
+      mat_local_output = mat_mpi_output->A;
+      mat_nonlocal_output = mat_mpi_output->B;  
+      MatGetSize(mat_nonlocal_output, &rows_ao_output, &cols_ao_output); 
+
+      colmap_output_h = PetscIntKokkosViewHost(mat_mpi_output->garray, cols_ao_output);
+      colmap_output_d = PetscIntKokkosView("colmap_output_d", cols_ao_output);
+      Kokkos::deep_copy(colmap_output_d, colmap_output_h); 
+
+      bytes = colmap_output_h.extent(0) * sizeof(PetscInt);
+      PetscLogCpuToGpu(bytes);      
+ 
+   }
+   else
+   {
+      mat_local = *input_mat;
+      mat_local_output = *output_mat;
+   }
+
+   // ~~~~~~~~~~~~
+   // Get pointers to the i,j,vals on the device
+   // ~~~~~~~~~~~~
+   const PetscInt *device_local_i = nullptr, *device_local_j = nullptr, *device_nonlocal_i = nullptr, *device_nonlocal_j = nullptr;
+   PetscMemType mtype;
+   PetscScalar *device_local_vals = nullptr, *device_nonlocal_vals = nullptr;  
+   MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, &device_local_vals, &mtype);  
+   if (mpi) MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype);          
+
+   // Get the output pointers
+   const PetscInt *device_local_i_output = nullptr, *device_local_j_output = nullptr, *device_nonlocal_i_output = nullptr, *device_nonlocal_j_output = nullptr;
+   PetscScalar *device_local_vals_output = nullptr, *device_nonlocal_vals_output = nullptr;  
+   MatSeqAIJGetCSRAndMemType(mat_local_output, &device_local_i_output, &device_local_j_output, &device_local_vals_output, &mtype);  
+   if (mpi) MatSeqAIJGetCSRAndMemType(mat_nonlocal_output, &device_nonlocal_i_output, &device_nonlocal_j_output, &device_nonlocal_vals_output, &mtype); 
+
+   Mat_SeqAIJKokkos *aijkok_local_output = static_cast<Mat_SeqAIJKokkos *>(mat_local_output->spptr);
+   Mat_SeqAIJKokkos *aijkok_nonlocal_output;
+   if (mpi) aijkok_nonlocal_output = static_cast<Mat_SeqAIJKokkos *>(mat_nonlocal_output->spptr);   
+
+   // Find maximum non-zeros per row of the input mat for sizing scratch memory
+   PetscInt max_nnz = 0;
+   if (local_rows > 0) {
+
+      Kokkos::parallel_reduce("FindMaxNNZSparsity", local_rows,
+         KOKKOS_LAMBDA(const PetscInt i, PetscInt& thread_max) {
+            PetscInt row_nnz = device_local_i[i + 1] - device_local_i[i];
+            if (mpi) row_nnz += device_nonlocal_i[i + 1] - device_nonlocal_i[i];
+            thread_max = (row_nnz > thread_max) ? row_nnz : thread_max;
+         },
+         Kokkos::Max<PetscInt>(max_nnz)
+      );
+   }   
+
+   auto exec = PetscGetKokkosExecutionSpace();
+   
+   // Create a team policy with scratch memory allocation
+   // We want scratch space for each row
+   // We will have ncols of integers which tell us what the matching indices we have
+   // the last bit of memory is to account for 8-byte alignment for each view
+   size_t scratch_size_per_team = max_nnz * sizeof(PetscInt) + \
+               8 * sizeof(PetscScalar);
+
+   Kokkos::TeamPolicy<> policy(exec, local_rows, Kokkos::AUTO());
+   // We're gonna use the level 1 scratch as our column data is probably bigger than the level 0
+   policy.set_scratch_size(1, Kokkos::PerTeam(scratch_size_per_team));
+
+   // Execute with scratch memory
+   Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
+
+      // Row
+      PetscInt i = t.league_rank();
+
+      // ncols is the total number of columns in this row of the input mat
+      PetscInt ncols_local = device_local_i[i + 1] - device_local_i[i];
+      PetscInt ncols = ncols_local;
+      if (mpi) ncols += device_nonlocal_i[i + 1] - device_nonlocal_i[i];
+
+      // ncols is the total number of columns in this row of the input mat
+      PetscInt ncols_output = device_local_i_output[i + 1] - device_local_i_output[i];
+      if (mpi) ncols_output += device_nonlocal_i_output[i + 1] - device_nonlocal_i_output[i];      
+
+      // Allocate views directly on scratch memory
+      // Have to use views here given alignment issues
+      ScratchIntView scratch_indices(t.team_scratch(1), ncols); 
+
+      // This is first nonlocal column of input mat is in this row
+      PetscInt start_nonlocal_idx = 0;
+      if (mpi)
+      {
+         start_nonlocal_idx = ncols_local;  
+      }         
+      else
+      {
+         start_nonlocal_idx = ncols;
+      }
+
+      PetscInt start_nonlocal_idx_output = 0;
+      if (mpi)
+      {
+         start_nonlocal_idx_output = device_local_i_output[i + 1] - device_local_i_output[i];  
+      }         
+      else
+      {
+         start_nonlocal_idx_output = ncols_output;
+      }      
+
+      // Initialize scratch
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+            scratch_indices(j) = -1;
+      });
+      // Team barrier to ensure all threads have finished filling the scratch space
+      t.team_barrier();      
+
+      // Perform Sorted Merge using a single thread per team
+      // Should be faster than having each input column loop through every output column in parallel
+      Kokkos::single(Kokkos::PerTeam(t), [&]() {
+         PetscInt idx_input = 0;  // Pointer for input columns (0 to ncols-1)
+         PetscInt idx_output = 0; // Pointer for output columns (0 to ncols_output-1)
+
+         while (idx_input < ncols && idx_output < ncols_output) {
+            // Get current global input column index
+            PetscInt col_input;
+            if (idx_input < start_nonlocal_idx) {
+               col_input = device_local_j[device_local_i[i] + idx_input] + global_col_start;
+            } else {
+               col_input = colmap_input_d(device_nonlocal_j[device_nonlocal_i[i] + (idx_input - start_nonlocal_idx)]);
+            }
+
+            // Get current global output column index
+            PetscInt col_output;
+            if (idx_output < start_nonlocal_idx_output) {
+               col_output = device_local_j_output[device_local_i_output[i] + idx_output] + global_col_start;
+            } else {
+               col_output = colmap_output_d(device_nonlocal_j_output[device_nonlocal_i_output[i] + (idx_output - start_nonlocal_idx_output)]);
+            }
+
+            // Compare and advance pointers
+            if (col_input == col_output) {
+               // Match found! Record output index
+               scratch_indices(idx_input) = idx_output;
+               idx_input++;
+               idx_output++;
+            } else if (col_input < col_output) {
+               idx_input++;
+            } else {
+               idx_output++;
+            }
+         }
+      });
+
+      // Team barrier to ensure all threads have finished filling the scratch space
+      t.team_barrier();      
+
+      PetscScalar lump_val = 0.0;
+      // If lumping need to sum all the non-matching non-diagonal terms in input
+      if (lump_int)
+      {
+         // Reduce over columns
+         Kokkos::parallel_reduce(
+            Kokkos::TeamThreadRange(t, ncols),
+            [&](const PetscInt j, PetscScalar& thread_sum) {
+
+               // Get the global column index we want to match
+               PetscScalar thread_val = 0.0;
+               if (j < start_nonlocal_idx)
+               {
+                  thread_val = device_local_vals[device_local_i[i] + j];
+               }
+               // Nonlocal part
+               else
+               {
+                  thread_val = device_nonlocal_vals[device_nonlocal_i[i] + (j - start_nonlocal_idx)];
+               }                
+
+               // If this is not being put into output then we lump it
+               if (scratch_indices(j) == -1) thread_sum += thread_val;
+            },
+            Kokkos::Sum<PetscScalar>(lump_val)
+         );   
+      }   
+
+      // Now go and write to the output
+      Kokkos::parallel_for(Kokkos::TeamThreadRange(t, ncols), [&](const PetscInt j) {
+
+         // Get the value we're copying
+         PetscScalar val_input;
+         if (j < start_nonlocal_idx)
+         {
+            val_input = device_local_vals[device_local_i[i] + j];
+         }
+         // Nonlocal part
+         else
+         {
+            val_input = device_nonlocal_vals[device_nonlocal_i[i] + (j - start_nonlocal_idx)];
+         }   
+
+         // If we have a match, copy the value
+         if (scratch_indices(j) != -1)
+         {
+            // If we're in the local part of the matrix
+            if (scratch_indices(j) < start_nonlocal_idx_output)
+            {
+               device_local_vals_output[device_local_i_output[i] + scratch_indices(j)] = val_input;
+            }
+            // Nonlocal part
+            else
+            {
+               device_nonlocal_vals_output[device_nonlocal_i_output[i] + (scratch_indices(j) - start_nonlocal_idx_output)] = val_input;                  
+            }
+         }
+      });     
+      
+      // Team barrier to ensure all threads have finished writing to output
+      t.team_barrier();      
+
+      // Add in the lumped value to the diagonal
+      if (lump_int)
+      {
+         // Only loop over the ncols in the local component
+         // Assuming diagonal is in the local component (ie square matrix)
+         Kokkos::parallel_for(Kokkos::TeamThreadRange(t, device_local_i_output[i + 1] - device_local_i_output[i]), [&](const PetscInt j) {
+
+            // Is this column the diagonal
+            bool is_diagonal = device_local_j_output[device_local_i_output[i] + j] + global_col_start == i + global_row_start;
+
+            // Will only happen for one thread
+            if (is_diagonal) device_local_vals_output[device_local_i_output[i] + j] += lump_val;
+         });   
+      }       
+   });
+
+   // Have to specify we've modifed data on the device
+   // Want to call MatSeqAIJKokkosModifyDevice but its PETSC_INTERN
+   aijkok_local_output->a_dual.clear_sync_state();
+   aijkok_local_output->a_dual.modify_device();
+   aijkok_local_output->transpose_updated = PETSC_FALSE;
+   aijkok_local_output->hermitian_updated = PETSC_FALSE;
+   // Invalidate diagonals
+   Mat_SeqAIJ *a = (Mat_SeqAIJ *)mat_local_output->data;
+   a->idiagvalid  = PETSC_FALSE;
+   a->ibdiagvalid = PETSC_FALSE;      
+   a->inode.ibdiagvalid = PETSC_FALSE;      
+   if (mpi)
+   {
+      aijkok_nonlocal_output->a_dual.clear_sync_state();
+      aijkok_nonlocal_output->a_dual.modify_device();
+      aijkok_nonlocal_output->transpose_updated = PETSC_FALSE;
+      aijkok_nonlocal_output->hermitian_updated = PETSC_FALSE;
+      a = (Mat_SeqAIJ *)mat_nonlocal_output->data;
+      a->idiagvalid  = PETSC_FALSE;
+      a->ibdiagvalid = PETSC_FALSE;   
+      a->inode.ibdiagvalid = PETSC_FALSE;       
+   }        
+   PetscObjectStateIncrease((PetscObject)(*output_mat));    
+
+   return;
+}
+
 //------------------------------------------------------------------------------------------------------------------------
 
 // Stick W in a full sized P but with kokkos - keeping everything on the device


### PR DESCRIPTION
Dropping entries according to a set sparsity now uses the GPU. So the reuse now fully uses the GPU.