### PR TITLE
Cf split no h2d copy

### DIFF
--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -31,7 +31,7 @@ using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::Me
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);
-PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat*, IS*, IS*, Mat*);
+PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat*, IS*, IS*, const int, Mat*);
 
 // ~~~~~~~~~~~~~~~~~~
 // Some custom reductions we use 

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -28,15 +28,15 @@ using ScratchIntView = Kokkos::View<PetscInt*, ScratchSpace, Kokkos::MemoryUnman
 using ScratchScalarView = Kokkos::View<PetscScalar*, ScratchSpace, Kokkos::MemoryUnmanaged>;
 using Scratch2DIntView = Kokkos::View<PetscInt**, ScratchSpace, Kokkos::MemoryUnmanaged>;
 using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::MemoryUnmanaged>;
+using ViewPetscIntPtr = std::shared_ptr<PetscIntKokkosView>;
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);
 
 // Define array of shared pointers representing fine and coarse IS's 
 // on each level on the device
-using ViewPtr = std::shared_ptr<PetscIntKokkosView>;
-extern ViewPtr* IS_fine_views_local;
-extern ViewPtr* IS_coarse_views_local;
+extern ViewPetscIntPtr* IS_fine_views_local;
+extern ViewPetscIntPtr* IS_coarse_views_local;
 extern int max_levels;
 
 // ~~~~~~~~~~~~~~~~~~

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -31,6 +31,7 @@ using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::Me
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);
+PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat*, IS*, IS*, Mat*);
 
 // ~~~~~~~~~~~~~~~~~~
 // Some custom reductions we use 

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -31,7 +31,13 @@ using Scratch2DScalarView = Kokkos::View<PetscScalar**, ScratchSpace, Kokkos::Me
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);
-PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat*, IS*, IS*, const int, Mat*);
+
+// Define array of shared pointers representing fine and coarse IS's 
+// on each level on the device
+using ViewPtr = std::shared_ptr<PetscIntKokkosView>;
+extern ViewPtr* IS_fine_views_local;
+extern ViewPtr* IS_coarse_views_local;
+extern int max_levels;
 
 // ~~~~~~~~~~~~~~~~~~
 // Some custom reductions we use 

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -360,9 +360,12 @@ module air_mg_setup
                      air_data%A_ff(our_level), ierr)         
             end if
          else
-            call MatCreateSubMatrix(air_data%coarse_matrix(our_level), &
-                  air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-                  air_data%A_ff(our_level), ierr)
+            ! call MatCreateSubMatrix(air_data%coarse_matrix(our_level), &
+            !       air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
+            !       air_data%A_ff(our_level), ierr)
+            call MatCreateSubMatrixWrapper(air_data%coarse_matrix(our_level), &
+                  air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), &
+                  air_data%A_ff(our_level))                 
          end if
                   
          call timer_finish(TIMER_ID_AIR_EXTRACT)   

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -355,16 +355,13 @@ module air_mg_setup
 
             ! If its not matdiagonal we can do reuse as normal
             else
-               call MatCreateSubMatrix(air_data%coarse_matrix(our_level), &
+               call MatCreateSubMatrixWrapper(air_data%coarse_matrix(our_level), &
                      air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-                     air_data%A_ff(our_level), ierr)         
+                     air_data%A_ff(our_level))         
             end if
          else
-            ! call MatCreateSubMatrix(air_data%coarse_matrix(our_level), &
-            !       air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-            !       air_data%A_ff(our_level), ierr)
             call MatCreateSubMatrixWrapper(air_data%coarse_matrix(our_level), &
-                  air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), &
+                  air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
                   air_data%A_ff(our_level))                 
          end if
                   

--- a/src/AIR_Operators_Setup.F90
+++ b/src/AIR_Operators_Setup.F90
@@ -80,7 +80,7 @@ module air_operators_setup
          else
             call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)  
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)              
          end if
                      
          call timer_finish(TIMER_ID_AIR_EXTRACT)                             

--- a/src/AIR_Operators_Setup.F90
+++ b/src/AIR_Operators_Setup.F90
@@ -76,11 +76,13 @@ module air_operators_setup
          if (.NOT. PetscObjectIsNull(temp_mat)) then
             call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP))              
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), &
+                        our_level = our_level, is_row_fine = .TRUE., is_col_fine = .TRUE.)              
          else
             call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP))                           
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), &
+                        our_level = our_level, is_row_fine = .TRUE., is_col_fine = .TRUE.)                              
          end if
                      
          call timer_finish(TIMER_ID_AIR_EXTRACT)                             
@@ -139,11 +141,13 @@ module air_operators_setup
          if (air_data%allocated_matrices_A_cc(our_level)) then
             call MatCreateSubMatrixWrapper(input_mat, &
                   air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
-                  air_data%A_cc(our_level))             
+                  air_data%A_cc(our_level), &
+                  our_level = our_level, is_row_fine = .FALSE., is_col_fine = .FALSE.)            
          else
             call MatCreateSubMatrixWrapper(input_mat, &
                   air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-                  air_data%A_cc(our_level))             
+                  air_data%A_cc(our_level), &
+                  our_level = our_level, is_row_fine = .FALSE., is_col_fine = .FALSE.)                
          end if
 
          call timer_start(TIMER_ID_AIR_INVERSE)    
@@ -171,17 +175,21 @@ module air_operators_setup
       if (air_data%allocated_matrices_A_ff(our_level)) then
          call MatCreateSubMatrixWrapper(input_mat, &
                air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
-               air_data%A_fc(our_level))   
+               air_data%A_fc(our_level), &
+               our_level = our_level, is_row_fine = .TRUE., is_col_fine = .FALSE.)   
       call MatCreateSubMatrixWrapper(input_mat, &
                air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-               air_data%A_cf(our_level))                     
+               air_data%A_cf(our_level), &
+               our_level = our_level, is_row_fine = .FALSE., is_col_fine = .TRUE.)                      
       else 
          call MatCreateSubMatrixWrapper(input_mat, &
                air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-               air_data%A_fc(our_level)) 
+               air_data%A_fc(our_level), &
+               our_level = our_level, is_row_fine = .TRUE., is_col_fine = .FALSE.) 
          call MatCreateSubMatrixWrapper(input_mat, &
                air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-               air_data%A_cf(our_level))                                                                   
+               air_data%A_cf(our_level), &
+               our_level = our_level, is_row_fine = .FALSE., is_col_fine = .TRUE.)                                                                    
       end if
 
       call timer_finish(TIMER_ID_AIR_EXTRACT)   
@@ -208,11 +216,13 @@ module air_operators_setup
          if (.NOT. PetscObjectIsNull(temp_mat)) then
             call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP))              
+                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), &
+                        our_level = our_level, is_row_fine = .FALSE., is_col_fine = .TRUE.)               
          else
             call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP))            
+                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), &
+                        our_level = our_level, is_row_fine = .FALSE., is_col_fine = .TRUE.)             
          end if
 
          if (.NOT. air_data%options%one_point_classical_prolong) then
@@ -221,11 +231,13 @@ module air_operators_setup
             if (.NOT. PetscObjectIsNull(temp_mat)) then
                call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP))
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), &
+                        our_level = our_level, is_row_fine = .TRUE., is_col_fine = .FALSE.)
             else
                call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
                         air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP))                
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), &
+                        our_level = our_level, is_row_fine = .TRUE., is_col_fine = .FALSE.)
             end if
          end if                  
          

--- a/src/AIR_Operators_Setup.F90
+++ b/src/AIR_Operators_Setup.F90
@@ -74,15 +74,12 @@ module air_operators_setup
          ! Pull out A_ff
          temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP)
          if (.NOT. PetscObjectIsNull(temp_mat)) then
-            call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)              
-         else
-            ! call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-            !             air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-            !             air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)
             call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), &
+                        air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP))              
+         else
+            call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+                        air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
                         air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP))                           
          end if
                      
@@ -140,15 +137,12 @@ module air_operators_setup
       if (air_data%options%any_c_smooths .AND. .NOT. air_data%options%full_smoothing_up_and_down) then
 
          if (air_data%allocated_matrices_A_cc(our_level)) then
-            call MatCreateSubMatrix(input_mat, &
-                  air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
-                  air_data%A_cc(our_level), ierr)             
-         else
-            ! call MatCreateSubMatrix(input_mat, &
-            !       air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-            !       air_data%A_cc(our_level), ierr)   
             call MatCreateSubMatrixWrapper(input_mat, &
-                  air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), &
+                  air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
+                  air_data%A_cc(our_level))             
+         else
+            call MatCreateSubMatrixWrapper(input_mat, &
+                  air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
                   air_data%A_cc(our_level))             
          end if
 
@@ -175,24 +169,18 @@ module air_operators_setup
       call timer_start(TIMER_ID_AIR_EXTRACT)             
                         
       if (air_data%allocated_matrices_A_ff(our_level)) then
-         call MatCreateSubMatrix(input_mat, &
-               air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
-               air_data%A_fc(our_level), ierr)   
-      call MatCreateSubMatrix(input_mat, &
-               air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-               air_data%A_cf(our_level), ierr)                     
-      else
-         ! call MatCreateSubMatrix(input_mat, &
-         !       air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-         !       air_data%A_fc(our_level), ierr) 
-         ! call MatCreateSubMatrix(input_mat, &
-         !       air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-         !       air_data%A_cf(our_level), ierr)  
          call MatCreateSubMatrixWrapper(input_mat, &
-               air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), &
+               air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
+               air_data%A_fc(our_level))   
+      call MatCreateSubMatrixWrapper(input_mat, &
+               air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
+               air_data%A_cf(our_level))                     
+      else 
+         call MatCreateSubMatrixWrapper(input_mat, &
+               air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
                air_data%A_fc(our_level)) 
          call MatCreateSubMatrixWrapper(input_mat, &
-               air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), &
+               air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
                air_data%A_cf(our_level))                                                                   
       end if
 
@@ -218,16 +206,12 @@ module air_operators_setup
          ! Drop the entries from A_cf
          temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP)
          if (.NOT. PetscObjectIsNull(temp_mat)) then
-            call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), ierr)              
-         else
-
-            ! call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-            !             air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-            !             air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), ierr)  
             call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), &
+                        air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
+                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP))              
+         else
+            call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+                        air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
                         air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP))            
          end if
 
@@ -235,15 +219,12 @@ module air_operators_setup
             ! Drop the entries from A_fc
             temp_mat = air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP)
             if (.NOT. PetscObjectIsNull(temp_mat)) then
-               call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), ierr)
-            else
-               ! call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-               !          air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-               !          air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), ierr)  
                call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), &
+                        air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP))
+            else
+               call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+                        air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
                         air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP))                
             end if
          end if                  

--- a/src/AIR_Operators_Setup.F90
+++ b/src/AIR_Operators_Setup.F90
@@ -78,9 +78,12 @@ module air_operators_setup
                         air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
                         air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)              
          else
-            call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)              
+            ! call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+            !             air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
+            !             air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP), ierr)
+            call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+                        air_data%IS_fine_index(our_level), air_data%IS_fine_index(our_level), &
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFF_DROP))                           
          end if
                      
          call timer_finish(TIMER_ID_AIR_EXTRACT)                             
@@ -141,9 +144,12 @@ module air_operators_setup
                   air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
                   air_data%A_cc(our_level), ierr)             
          else
-            call MatCreateSubMatrix(input_mat, &
-                  air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-                  air_data%A_cc(our_level), ierr)   
+            ! call MatCreateSubMatrix(input_mat, &
+            !       air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
+            !       air_data%A_cc(our_level), ierr)   
+            call MatCreateSubMatrixWrapper(input_mat, &
+                  air_data%IS_coarse_index(our_level), air_data%IS_coarse_index(our_level), &
+                  air_data%A_cc(our_level))             
          end if
 
          call timer_start(TIMER_ID_AIR_INVERSE)    
@@ -176,12 +182,18 @@ module air_operators_setup
                air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_REUSE_MATRIX, &
                air_data%A_cf(our_level), ierr)                     
       else
-         call MatCreateSubMatrix(input_mat, &
-               air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-               air_data%A_fc(our_level), ierr) 
-         call MatCreateSubMatrix(input_mat, &
-               air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-               air_data%A_cf(our_level), ierr)                                                          
+         ! call MatCreateSubMatrix(input_mat, &
+         !       air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
+         !       air_data%A_fc(our_level), ierr) 
+         ! call MatCreateSubMatrix(input_mat, &
+         !       air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
+         !       air_data%A_cf(our_level), ierr)  
+         call MatCreateSubMatrixWrapper(input_mat, &
+               air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), &
+               air_data%A_fc(our_level)) 
+         call MatCreateSubMatrixWrapper(input_mat, &
+               air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), &
+               air_data%A_cf(our_level))                                                                   
       end if
 
       call timer_finish(TIMER_ID_AIR_EXTRACT)   
@@ -211,9 +223,12 @@ module air_operators_setup
                         air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), ierr)              
          else
 
-            call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), ierr)  
+            ! call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+            !             air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), MAT_INITIAL_MATRIX, &
+            !             air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP), ierr)  
+            call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+                        air_data%IS_coarse_index(our_level), air_data%IS_fine_index(our_level), &
+                        air_data%reuse(our_level)%reuse_mat(MAT_ACF_DROP))            
          end if
 
          if (.NOT. air_data%options%one_point_classical_prolong) then
@@ -224,9 +239,12 @@ module air_operators_setup
                         air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_REUSE_MATRIX, &
                         air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), ierr)
             else
-               call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
-                        air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
-                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), ierr)  
+               ! call MatCreateSubMatrix(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+               !          air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), MAT_INITIAL_MATRIX, &
+               !          air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP), ierr)  
+               call MatCreateSubMatrixWrapper(air_data%reuse(our_level)%reuse_mat(MAT_A_DROP), &
+                        air_data%IS_fine_index(our_level), air_data%IS_coarse_index(our_level), &
+                        air_data%reuse(our_level)%reuse_mat(MAT_AFC_DROP))                
             end if
          end if                  
          

--- a/src/CF_Splitting.F90
+++ b/src/CF_Splitting.F90
@@ -353,8 +353,10 @@ module cf_splitting
       integer :: its
       logical :: need_intermediate_is
 #if defined(PETSC_HAVE_KOKKOS)                     
-      type(c_ptr)  :: cf_markers_local_ptr
       MatType :: mat_type
+      integer(c_long_long) :: A_array, is_fine_array, is_coarse_array
+      type(tIS) :: is_fine_kokkos, is_coarse_kokkos
+      PetscBool :: fine_equal, coarse_equal
 #endif       
 
       ! ~~~~~~  
@@ -372,7 +374,10 @@ module cf_splitting
             ! If kokkos debugging is on, the pmisr and ddc do 
             ! copy to the host after they finish in order to do the comparisons
             ! and hence we do need the intermediate ISs
-            if (.NOT. kokkos_debug()) then 
+            ! If doing pmis agg, the initial pmis will be on the device so always
+            ! trigger the d2h copy and build the intermediate is
+            if (.NOT. kokkos_debug() .AND. &
+                  (cf_splitting_type /= CF_AGG .AND. cf_splitting_type /= CF_PMIS_AGG)) then 
                need_intermediate_is = .FALSE.  
             end if
       end if                     
@@ -391,7 +396,7 @@ module cf_splitting
 
          do its = 1, ddc_its
             ! Do the second pass cleanup - this will directly modify the values in cf_markers_local
-            ! (or the equivalent device cf_markers)
+            ! (or the equivalent device cf_markers, is_fine is ignored if on the device)
             call ddc(input_mat, is_fine, fraction_swap, cf_markers_local)
 
             ! If we did anything in our ddc second pass and hence need to rebuild
@@ -411,21 +416,60 @@ module cf_splitting
       ! The Kokkos PMISR and DDC no longer copy back to the host to save copies
       ! during an arbritrary number of iterations above     
       ! We need to explicitly copy the cf_markers_local back to the host once 
-      ! we've finished both the PMISR and all the DDC iterations      
+      ! we've finished both the PMISR and all the DDC iterations  
+      ! And we also need to build the host IS's    
 #if defined(PETSC_HAVE_KOKKOS)    
 
-         call MatGetType(input_mat, mat_type, ierr)
-         if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
-               mat_type == MATAIJKOKKOS) then 
+      if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
+            mat_type == MATAIJKOKKOS) then
 
-         cf_markers_local_ptr = c_loc(cf_markers_local)
-         ! This copies the device cf markers back to the host and destroys 
-         ! the device data          
-         call copy_cf_markers_d2h_and_delete(cf_markers_local_ptr)                   
-         if (.NOT. kokkos_debug()) then 
-            ! Create the host is_fine and is_coarse ISs
-            call create_cf_is(input_mat, cf_markers_local, is_fine, is_coarse)  
+         ! The initial pmis will be on the device, so need to destroy
+         ! Intermediate ISs are created in that case
+         if (cf_splitting_type == CF_PMIS_AGG) then
+            ! Destroys the device cf_markers_local
+            call delete_device_cf_markers()
          end if
+      
+         ! Aggregation is not on the device at all
+         if (cf_splitting_type /= CF_AGG .AND. cf_splitting_type /= CF_PMIS_AGG) then
+
+            A_array = input_mat%v
+            is_fine_array = is_fine_kokkos%v
+            is_coarse_array = is_coarse_kokkos%v
+
+            ! Create the host is_fine and is_coarse based on device cf_markers
+            call create_cf_is_kokkos(A_array, is_fine_array, is_coarse_array)  
+            is_fine_kokkos%v = is_fine_array
+            is_coarse_kokkos%v = is_coarse_array         
+            
+            ! If we are doing debugging the IS's are already created above
+            ! so let's compare them to our kokkos ones
+            if (kokkos_debug()) then 
+
+               call ISEqual(is_fine, is_fine_kokkos, fine_equal, ierr)
+               if (.NOT. fine_equal) then
+                  print *, "Kokkos and CPU versions of create_cf_is_kokkos for fine do not match"
+                  call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, ierr)
+               end if
+               call ISEqual(is_coarse, is_coarse_kokkos, coarse_equal, ierr)
+               if (.NOT. coarse_equal) then
+                  print *, "Kokkos and CPU versions of create_cf_is_kokkos for coarse do not match"
+                  call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, ierr)
+               end if
+               ! Destroy the extra IS's
+               call ISDestroy(is_fine_kokkos, ierr)
+               call ISDestroy(is_coarse_kokkos, ierr)
+
+            ! If we're not debugging just copy over the ones we built on the device            
+            else
+               is_fine = is_fine_kokkos
+               is_coarse = is_coarse_kokkos
+            end if
+
+            ! Destroys the device cf_markers_local
+            call delete_device_cf_markers()
+         end if
+
       end if    
 #endif       
 

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -440,7 +440,20 @@ module c_petsc_interfaces
          PetscScalar, value :: alpha
       end subroutine MatAXPY_kokkos         
  
-   end interface    
+   end interface
+   
+   interface   
+      
+      subroutine MatCreateSubMatrix_kokkos(A_array, is_row, is_col, B_array) &
+         bind(c, name="MatCreateSubMatrix_kokkos")
+         use iso_c_binding
+         integer(c_long_long) :: A_array
+         integer(c_long_long) :: B_array
+         integer(c_long_long) :: is_row, is_col
+
+      end subroutine MatCreateSubMatrix_kokkos
+
+   end interface
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -312,6 +312,18 @@ module c_petsc_interfaces
 
    interface   
       
+      subroutine create_cf_is_kokkos(A_array, index_fine, index_coarse) &
+         bind(c, name="create_cf_is_kokkos")
+         use iso_c_binding
+         integer(c_long_long) :: A_array
+         integer(c_long_long) :: index_fine
+         integer(c_long_long) :: index_coarse
+      end subroutine create_cf_is_kokkos         
+ 
+   end interface   
+
+   interface   
+      
       subroutine pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local, zero_meaure_c_point_int) &
          bind(c, name="pmisr_kokkos")
          use iso_c_binding
@@ -341,17 +353,16 @@ module c_petsc_interfaces
          type(c_ptr), value :: cf_markers_local
       end subroutine copy_cf_markers_d2h         
  
-   end interface     
+   end interface 
    
    interface   
       
-      subroutine copy_cf_markers_d2h_and_delete(cf_markers_local) &
-         bind(c, name="copy_cf_markers_d2h_and_delete")
+      subroutine delete_device_cf_markers() &
+         bind(c, name="delete_device_cf_markers")
          use iso_c_binding
-         type(c_ptr), value :: cf_markers_local
-      end subroutine copy_cf_markers_d2h_and_delete         
+      end subroutine delete_device_cf_markers         
  
-   end interface     
+   end interface       
 
    interface   
       

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -312,28 +312,46 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local, cf_markers_local, zero_meaure_c_point_int) &
+      subroutine pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local, zero_meaure_c_point_int) &
          bind(c, name="pmisr_kokkos")
          use iso_c_binding
          integer(c_long_long) :: A_array
          type(c_ptr), value :: measure_local
          integer(c_int), value :: max_luby_steps, pmis_int, zero_meaure_c_point_int
-         type(c_ptr), value :: cf_markers_local
       end subroutine pmisr_kokkos         
  
    end interface     
 
    interface   
       
-      subroutine ddc_kokkos(A_array, indices, fraction_swap, cf_markers_local) &
+      subroutine ddc_kokkos(A_array, indices, fraction_swap) &
          bind(c, name="ddc_kokkos")
          use iso_c_binding
          integer(c_long_long) :: A_array, indices
          PetscReal, value :: fraction_swap
-         type(c_ptr), value :: cf_markers_local
       end subroutine ddc_kokkos         
  
-   end interface      
+   end interface 
+   
+   interface   
+      
+      subroutine copy_cf_markers_d2h(cf_markers_local) &
+         bind(c, name="copy_cf_markers_d2h")
+         use iso_c_binding
+         type(c_ptr), value :: cf_markers_local
+      end subroutine copy_cf_markers_d2h         
+ 
+   end interface     
+   
+   interface   
+      
+      subroutine copy_cf_markers_d2h_and_delete(cf_markers_local) &
+         bind(c, name="copy_cf_markers_d2h_and_delete")
+         use iso_c_binding
+         type(c_ptr), value :: cf_markers_local
+      end subroutine copy_cf_markers_d2h_and_delete         
+ 
+   end interface     
 
    interface   
       

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -444,13 +444,15 @@ module c_petsc_interfaces
    
    interface   
       
-      subroutine MatCreateSubMatrix_kokkos(A_array, is_row, is_col, reuse_int, B_array) &
+      subroutine MatCreateSubMatrix_kokkos(A_array, is_row, is_col, &
+                     reuse_int, B_array, &
+                     our_level, is_row_fine_int, is_col_fine_int) &
          bind(c, name="MatCreateSubMatrix_kokkos")
          use iso_c_binding
          integer(c_long_long) :: A_array
          integer(c_long_long) :: B_array
          integer(c_long_long) :: is_row, is_col
-         integer(c_int), value :: reuse_int
+         integer(c_int), value :: our_level, is_row_fine_int, is_col_fine_int, reuse_int
 
       end subroutine MatCreateSubMatrix_kokkos
 

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -324,10 +324,10 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine ddc_kokkos(A_array, indices, fraction_swap) &
+      subroutine ddc_kokkos(A_array, fraction_swap) &
          bind(c, name="ddc_kokkos")
          use iso_c_binding
-         integer(c_long_long) :: A_array, indices
+         integer(c_long_long) :: A_array
          PetscReal, value :: fraction_swap
       end subroutine ddc_kokkos         
  

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -444,12 +444,13 @@ module c_petsc_interfaces
    
    interface   
       
-      subroutine MatCreateSubMatrix_kokkos(A_array, is_row, is_col, B_array) &
+      subroutine MatCreateSubMatrix_kokkos(A_array, is_row, is_col, reuse_int, B_array) &
          bind(c, name="MatCreateSubMatrix_kokkos")
          use iso_c_binding
          integer(c_long_long) :: A_array
          integer(c_long_long) :: B_array
          integer(c_long_long) :: is_row, is_col
+         integer(c_int), value :: reuse_int
 
       end subroutine MatCreateSubMatrix_kokkos
 

--- a/src/PETSc_Helper.F90
+++ b/src/PETSc_Helper.F90
@@ -1019,6 +1019,80 @@ logical, protected :: kokkos_debug_global = .FALSE.
          
    end subroutine MatAXPYWrapper   
 
+!------------------------------------------------------------------------------------------------------------------------
+   
+   subroutine MatCreateSubMatrixWrapper(input_mat, is_row, is_col, output_mat)
+
+      ! Wrapper around MatCreateSubMatrix_kokkos
+      ! Only works if the input IS have the same parallel row/column distribution 
+      ! as the matrices
+      ! is_col must be sorted
+   
+      ! ~~~~~~~~~~
+      ! Input 
+      type(tMat), intent(inout) :: input_mat
+      IS, intent(inout)         :: is_row, is_col
+      type(tMat), intent(inout) :: output_mat
+
+      MPI_Comm :: MPI_COMM_MATRIX
+      integer :: comm_size, errorcode
+      PetscErrorCode :: ierr
+#if defined(PETSC_HAVE_KOKKOS)                     
+      integer(c_long_long) :: A_array, B_array, is_row_ptr, is_col_ptr
+      MatType :: mat_type
+      Mat :: temp_mat
+      PetscScalar normy
+#endif      
+      ! ~~~~~~~~~~
+
+#if defined(PETSC_HAVE_KOKKOS)    
+
+      call MatGetType(input_mat, mat_type, ierr)
+      call PetscObjectGetComm(input_mat, MPI_COMM_MATRIX, ierr)  
+      ! Get the comm size 
+      call MPI_Comm_size(MPI_COMM_MATRIX, comm_size, errorcode)       
+
+      ! If doing parallel Kokkos
+      if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
+            mat_type == MATAIJKOKKOS) then
+
+         A_array = input_mat%v   
+         B_array = output_mat%v      
+         is_row_ptr = is_row%v
+         is_col_ptr = is_col%v
+         call MatCreateSubMatrix_kokkos(A_array, is_row_ptr, is_col_ptr, B_array) 
+         output_mat%v = B_array
+
+         ! If debugging do a comparison between CPU and Kokkos results
+         if (kokkos_debug()) then
+
+            call MatCreateSubMatrix(input_mat, is_row, is_col, &
+                  MAT_INITIAL_MATRIX, temp_mat, ierr)    
+
+            call MatAXPY(temp_mat, -1d0, output_mat, DIFFERENT_NONZERO_PATTERN, ierr)
+            call MatNorm(temp_mat, NORM_FROBENIUS, normy, ierr)
+            if (normy .gt. 1d-12 .OR. normy/=normy) then
+               !call MatFilter(temp_mat, 1d-14, PETSC_TRUE, PETSC_FALSE, ierr)
+               !call MatView(temp_mat, PETSC_VIEWER_STDOUT_WORLD, ierr)
+               print *, "Kokkos and CPU versions of MatCreateSubMatrix do not match"
+               call MPI_Abort(MPI_COMM_WORLD, MPI_ERR_OTHER, errorcode)  
+            end if
+            call MatDestroy(temp_mat, ierr)
+         end if
+
+      else
+
+         call MatCreateSubMatrix(input_mat, is_row, is_col, &
+               MAT_INITIAL_MATRIX, output_mat, ierr)        
+
+      end if
+#else
+         call MatCreateSubMatrix(input_mat, is_row, is_col, &
+               MAT_INITIAL_MATRIX, output_mat, ierr) 
+#endif  
+         
+   end subroutine MatCreateSubMatrixWrapper   
+
    !------------------------------------------------------------------------------------------------------------------------
    
    subroutine generate_identity(input_mat, output_mat)

--- a/src/PETSc_Helper.F90
+++ b/src/PETSc_Helper.F90
@@ -1030,8 +1030,8 @@ logical, protected :: kokkos_debug_global = .FALSE.
    
       ! ~~~~~~~~~~
       ! Input 
-      type(tMat), intent(inout) :: input_mat
-      IS, intent(inout)         :: is_row, is_col
+      type(tMat), intent(in)    :: input_mat
+      IS, intent(in)            :: is_row, is_col
       type(tMat), intent(inout) :: output_mat
 
       MPI_Comm :: MPI_COMM_MATRIX

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -2198,7 +2198,11 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
       // We also copy the input mat colmap over to the device as we need it
       colmap_input_h = PetscIntKokkosViewHost(mat_mpi->garray, cols_ao);
       colmap_input_d = PetscIntKokkosView("colmap_input_d", cols_ao);
-      Kokkos::deep_copy(colmap_input_d, colmap_input_h);        
+      Kokkos::deep_copy(colmap_input_d, colmap_input_h);       
+      
+      // Log copy with petsc
+      size_t bytes = colmap_input_h.extent(0) * sizeof(PetscInt);
+      PetscLogCpuToGpu(bytes);      
    }
    else
    {
@@ -2392,6 +2396,8 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
       PetscIntKokkosViewHost colmap_output_h = PetscIntKokkosViewHost(garray_host, col_ao_output);
       // Copy the garray output to the host
       Kokkos::deep_copy(colmap_output_h, garray_output_d);
+      bytes = colmap_output_h.extent(0) * sizeof(PetscInt);
+      PetscLogGpuToCpu(bytes);       
       
       // We can now create our MPI matrix
       MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows_row, global_cols_col, output_mat_local, output_mat_nonlocal, garray_host, output_mat);

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -2023,7 +2023,7 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
          
          // Perform exclusive scan over scratch_indices to get our output indices in this row
          // Have to be careful to go up to ncols_local+1
-         Kokkos::parallel_scan(Kokkos::TeamVectorRange(t, ncols_local+1), 
+         Kokkos::parallel_scan(Kokkos::TeamThreadRange(t, ncols_local+1), 
             [&](const PetscInt j, int& partial_sum, const bool is_final) {
                const int input_value = scratch_indices(j);
                if (is_final) {
@@ -2103,7 +2103,7 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
          
          // Perform exclusive scan over scratch_indices to get our output indices in this row
          // Have to be careful to go up to ncols_local+1
-         Kokkos::parallel_scan(Kokkos::TeamVectorRange(t, ncols_local+1), 
+         Kokkos::parallel_scan(Kokkos::TeamThreadRange(t, ncols_local+1), 
             [&](const PetscInt j, int& partial_sum, const bool is_final) {
                const int input_value = scratch_indices(j);
                if (is_final) {

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -1835,10 +1835,8 @@ PETSC_INTERN void MatAXPY_kokkos(Mat *Y, PetscScalar alpha, Mat *X)
 // Does a MatGetSubMatrix for a sequential Kokkos matrix - the petsc version currently uses the host making it very slow
 // is_row_view_d and is_col_view_d must have the local indices in them
 // is_col must be sorted
-PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosView &is_row_view_d, PetscIntKokkosView &is_col_view_d, Mat *output_mat)
+PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosView &is_row_view_d, PetscIntKokkosView &is_col_view_d, const int reuse_int, Mat *output_mat)
 {
-   int reuse_int = 0;
-
    PetscInt local_rows, local_cols;
    PetscInt nnzs_match_local;
 
@@ -2175,7 +2173,7 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
 // This version only works  works if the input IS have the same parallel row/column distribution 
 // as the matrices, ie equivalent to MatCreateSubMatrix_MPIAIJ_SameRowDist
 // is_col must be sorted
-PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_col, Mat *output_mat)
+PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_col, const int reuse_int, Mat *output_mat)
 {
    PetscInt local_rows, local_cols;
    PetscInt global_rows, global_cols;
@@ -2239,7 +2237,7 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
    });
 
    // Call the sequential code
-   MatCreateSubMatrix_Seq_kokkos(input_mat, is_row_view_d, is_col_view_d, output_mat);
+   MatCreateSubMatrix_Seq_kokkos(input_mat, is_row_view_d, is_col_view_d, reuse_int, output_mat);
 
    return;
 }

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -1986,9 +1986,10 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
 
       // Execute with scratch memory
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
-            
+         
+         // i_idx_is_row is the row index into the output
          const PetscInt i_idx_is_row = t.league_rank();
-         // The indices in is_row will be global, but we want the local index
+         // i is the row index into the input
          const PetscInt i = is_row_view_d(i_idx_is_row);       
 
          // number of columns
@@ -2066,9 +2067,10 @@ PETSC_INTERN void MatCreateSubMatrix_Seq_kokkos(Mat *input_mat, PetscIntKokkosVi
       // Execute with scratch memory
       Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const KokkosTeamMemberType& t) {
             
+         // i_idx_is_row is the row index into the output
          const PetscInt i_idx_is_row = t.league_rank();
-         // The indices in is_row will be global, but we want the local index
-         const PetscInt i = is_row_view_d(i_idx_is_row);       
+         // i is the row index into the input
+         const PetscInt i = is_row_view_d(i_idx_is_row);     
 
          // number of columns
          PetscInt ncols_local;

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -2392,7 +2392,6 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
                if (is_col_o_match_d(i+1) > is_col_o_match_d(i))
                {
                   is_col_o_d(is_col_o_match_d(i)) = i;
-                  // Is this not just is_col_o_match_d(i) + isstart??
                   garray_output_d(is_col_o_match_d(i)) = (PetscInt)lcmap_d_ptr[i];
                }
          });      

--- a/src/PETSc_Helperk.kokkos.cxx
+++ b/src/PETSc_Helperk.kokkos.cxx
@@ -2389,9 +2389,9 @@ PETSC_INTERN void MatCreateSubMatrix_kokkos(Mat *input_mat, IS *is_row, IS *is_c
       // Copy the garray output to the host
       PetscInt *garray_host = NULL; 
       PetscMalloc1(col_ao_output, &garray_host);
-      PetscIntKokkosViewHost colmap_input_h = PetscIntKokkosViewHost(garray_host, col_ao_output);
+      PetscIntKokkosViewHost colmap_output_h = PetscIntKokkosViewHost(garray_host, col_ao_output);
       // Copy the garray output to the host
-      Kokkos::deep_copy(colmap_input_h, garray_output_d);
+      Kokkos::deep_copy(colmap_output_h, garray_output_d);
       
       // We can now create our MPI matrix
       MatCreateMPIAIJWithSeqAIJ(MPI_COMM_MATRIX, global_rows_row, global_cols_col, output_mat_local, output_mat_nonlocal, garray_host, output_mat);

--- a/src/PMISR_DDC.F90
+++ b/src/PMISR_DDC.F90
@@ -670,7 +670,7 @@ module pmisr_ddc
       integer, dimension(:), allocatable, target, intent(inout) :: cf_markers_local
 
 #if defined(PETSC_HAVE_KOKKOS)                     
-      integer(c_long_long) :: A_array, indices
+      integer(c_long_long) :: A_array
       PetscErrorCode :: ierr
       MatType :: mat_type
       type(c_ptr)  :: cf_markers_local_ptr
@@ -692,7 +692,6 @@ module pmisr_ddc
             mat_type == MATAIJKOKKOS) then  
 
          A_array = input_mat%v  
-         indices = is_fine%v
          cf_markers_local_ptr = c_loc(cf_markers_local)
 
          ! If debugging do a comparison between CPU and Kokkos results
@@ -702,7 +701,7 @@ module pmisr_ddc
          end if
 
          ! Modifies the existing device cf_markers created by the pmisr
-         call ddc_kokkos(A_array, indices, fraction_swap)
+         call ddc_kokkos(A_array, fraction_swap)
 
          ! If debugging do a comparison between CPU and Kokkos results
          if (kokkos_debug()) then  

--- a/src/PMISR_DDC.F90
+++ b/src/PMISR_DDC.F90
@@ -778,9 +778,12 @@ module pmisr_ddc
       ! ~~~~~~~~~~~~~
  
       ! Pull out Aff for ease of use
-      call MatCreateSubMatrix(input_mat, &
-            is_fine, is_fine, MAT_INITIAL_MATRIX, &
-            Aff, ierr)
+      ! call MatCreateSubMatrix(input_mat, &
+      !       is_fine, is_fine, MAT_INITIAL_MATRIX, &
+      !       Aff, ierr)
+      call MatCreateSubMatrixWrapper(input_mat, &
+            is_fine, is_fine, &
+            Aff)      
 
       ! Can't put this above because of collective operations in parallel (namely the getsubmatrix)
       ! If we have local points to swap

--- a/src/PMISR_DDC.F90
+++ b/src/PMISR_DDC.F90
@@ -778,11 +778,8 @@ module pmisr_ddc
       ! ~~~~~~~~~~~~~
  
       ! Pull out Aff for ease of use
-      ! call MatCreateSubMatrix(input_mat, &
-      !       is_fine, is_fine, MAT_INITIAL_MATRIX, &
-      !       Aff, ierr)
       call MatCreateSubMatrixWrapper(input_mat, &
-            is_fine, is_fine, &
+            is_fine, is_fine, MAT_INITIAL_MATRIX, &
             Aff)      
 
       ! Can't put this above because of collective operations in parallel (namely the getsubmatrix)

--- a/src/PMISR_DDC.F90
+++ b/src/PMISR_DDC.F90
@@ -778,9 +778,9 @@ module pmisr_ddc
       ! ~~~~~~~~~~~~~
  
       ! Pull out Aff for ease of use
-      call MatCreateSubMatrixWrapper(input_mat, &
+      call MatCreateSubMatrix(input_mat, &
             is_fine, is_fine, MAT_INITIAL_MATRIX, &
-            Aff)      
+            Aff, ierr)      
 
       ! Can't put this above because of collective operations in parallel (namely the getsubmatrix)
       ! If we have local points to swap

--- a/src/PMISR_DDCk.kokkos.cxx
+++ b/src/PMISR_DDCk.kokkos.cxx
@@ -493,10 +493,9 @@ PETSC_INTERN void ddc_kokkos(Mat *input_mat, IS *is_fine, const PetscReal fracti
 
    // Pull out Aff for ease of use
    Mat Aff;
-   // MatCreateSubMatrix(*input_mat, \
-   //          *is_fine, *is_fine, MAT_INITIAL_MATRIX, \
-   //          &Aff);
-   MatCreateSubMatrix_kokkos(input_mat, is_fine, is_fine, &Aff);
+   const int reuse_int = 0;
+   // Call our device version
+   MatCreateSubMatrix_kokkos(input_mat, is_fine, is_fine, reuse_int, &Aff);
 
    // Can't put this above because of collective operations in parallel (namely the getsubmatrix)
    // If we have local points to swap

--- a/src/PMISR_DDCk.kokkos.cxx
+++ b/src/PMISR_DDCk.kokkos.cxx
@@ -90,7 +90,7 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
    if (mpi) MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, &device_nonlocal_vals, &mtype);          
 
    // Device memory for the global variable cf_markers_local_d - be careful these aren't petsc ints
-   cf_markers_local_d = intKokkosViewHost("cf_markers_local_d", local_rows);
+   cf_markers_local_d = intKokkosView("cf_markers_local_d", local_rows);
    PetscScalar *cf_markers_local_real_d_ptr = NULL, *cf_markers_nonlocal_real_d_ptr = NULL;
    // The real equivalents so we can use the existing petscsf from the input matrix
    PetscScalarKokkosView cf_markers_local_real_d("cf_markers_local_real_d", local_rows);

--- a/src/PMISR_DDCk.kokkos.cxx
+++ b/src/PMISR_DDCk.kokkos.cxx
@@ -493,9 +493,10 @@ PETSC_INTERN void ddc_kokkos(Mat *input_mat, IS *is_fine, const PetscReal fracti
 
    // Pull out Aff for ease of use
    Mat Aff;
-   MatCreateSubMatrix(*input_mat, \
-            *is_fine, *is_fine, MAT_INITIAL_MATRIX, \
-            &Aff);
+   // MatCreateSubMatrix(*input_mat, \
+   //          *is_fine, *is_fine, MAT_INITIAL_MATRIX, \
+   //          &Aff);
+   MatCreateSubMatrix_kokkos(input_mat, is_fine, is_fine, &Aff);
 
    // Can't put this above because of collective operations in parallel (namely the getsubmatrix)
    // If we have local points to swap

--- a/src/PMISR_DDCk.kokkos.cxx
+++ b/src/PMISR_DDCk.kokkos.cxx
@@ -664,7 +664,7 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, IS *is_row, PetscScalar
                      if (lvec_d_ptr[target_col] > -1.0)
                      {               
                         // Get the abs value of the entry
-                        sum_val += Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
+                        thread_sum += Kokkos::abs(device_nonlocal_vals[device_nonlocal_i[i] + j]);
                      }
                   },
                   Kokkos::Sum<PetscScalar>(sum_val)

--- a/src/PMISR_DDCk.kokkos.cxx
+++ b/src/PMISR_DDCk.kokkos.cxx
@@ -523,7 +523,7 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscIntKokkosView &is_
       KOKKOS_LAMBDA(const PetscInt i, PetscInt& update, const bool final_pass) {
          bool is_f_point = false;
          if (i < local_rows) { // Predicate is based on original data up to local_rows-1
-               is_f_point = (cf_markers_local_d(i) == -1);
+               is_f_point = (cf_markers_d(i) == -1);
          }         
          if (final_pass) {
                f_point_offsets_d(i) = update;

--- a/src/PMISR_DDCk.kokkos.cxx
+++ b/src/PMISR_DDCk.kokkos.cxx
@@ -511,7 +511,7 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, IS *is_row, PetscScalar
    // ~~~~~~~~~~~~~~~
    // Can now go and compute the diagonal dominance sums
    // ~~~~~~~~~~~~~~~
-   Vec x, lvec;
+   Vec x, lvec = NULL;
    PetscScalarKokkosView x_d, lvec_d;
    PetscScalar *x_d_ptr = NULL;
    PetscScalar *lvec_d_ptr = NULL;

--- a/src/VecISCopyLocalk.kokkos.cxx
+++ b/src/VecISCopyLocalk.kokkos.cxx
@@ -4,8 +4,8 @@
 
 // These are defined as extern in kokkos_helper.hpp but we allocate
 // them in this .cxx
-ViewPtr* IS_fine_views_local = nullptr;
-ViewPtr* IS_coarse_views_local = nullptr;
+ViewPetscIntPtr* IS_fine_views_local = nullptr;
+ViewPetscIntPtr* IS_coarse_views_local = nullptr;
 int max_levels = -1;
 
 //------------------------------------------------------------------------------------------------------------------------
@@ -38,14 +38,14 @@ PETSC_INTERN void create_VecISCopyLocal_kokkos(int max_levels_input)
       max_levels = max_levels_input;
 
       // Initialise fine
-      IS_fine_views_local = new ViewPtr[max_levels];
+      IS_fine_views_local = new ViewPetscIntPtr[max_levels];
       // Initialize each element as null until it's set
       // we don't want to accidently call the constructor on any of the views
       for (int i = 0; i < max_levels; i++) {
          IS_fine_views_local[i] = nullptr;
       }
       // Initialise coarse
-      IS_coarse_views_local = new ViewPtr[max_levels];
+      IS_coarse_views_local = new ViewPetscIntPtr[max_levels];
       for (int i = 0; i < max_levels; i++) {
          IS_coarse_views_local[i] = nullptr;
       }      

--- a/src/VecISCopyLocalk.kokkos.cxx
+++ b/src/VecISCopyLocalk.kokkos.cxx
@@ -2,10 +2,8 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 
-using ViewPtr = std::shared_ptr<PetscIntKokkosView>;
-
-// Define array of shared pointers representing fine and coarse IS's 
-// on each level on the device
+// These are defined as extern in kokkos_helper.hpp but we allocate
+// them in this .cxx
 ViewPtr* IS_fine_views_local = nullptr;
 ViewPtr* IS_coarse_views_local = nullptr;
 int max_levels = -1;


### PR DESCRIPTION
All of the cf_markers now stay on the device during the CF splitting. The fine/coarse indices are computed on the device and the matrix extract uses those indices on the device with no copy. 