### PR TITLE
Change the default coarsest inverse type to arnoldi for robustness.

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ A brief description of the available options in PFLARE are given below and their
 
    | Command line  | Routine | Description | Default |
    | ------------- | -- | ------------- | --- |
-   | ``-pc_air_coarsest_inverse_type``  |  PCAIRGetCoarsestInverseType  PCAIRSetCoarsestInverseType  | Coarse grid inverse type, given above | power |
+   | ``-pc_air_coarsest_inverse_type``  |  PCAIRGetCoarsestInverseType  PCAIRSetCoarsestInverseType  | Coarse grid inverse type, given above | arnoldi |
    | ``-pc_air_coarsest_poly_order``  |  PCAIRGetCoarsestPolyOrder  PCAIRSetCoarsestPolyOrder  | Coarse grid polynomial order | 6 |
    | ``-pc_air_coarsest_inverse_sparsity_order``  |  PCAIRGetCoarsestInverseSparsityOrder  PCAIRSetCoarsestInverseSparsityOrder  | Coarse grid sparsity order | 1 |
    | ``-pc_air_coarsest_matrix_free_polys``  |  PCAIRGetCoarsestMatrixFreePolys  PCAIRSetCoarsestMatrixFreePolys  | Do smoothing matrix-free if possible on the coarse grid | false |              

--- a/src/AIR_Data_Type.F90
+++ b/src/AIR_Data_Type.F90
@@ -204,7 +204,7 @@ module air_data_type
       
       ! These are for the coarse grid solver
       ! -pc_air_coarsest_inverse_type
-      integer :: coarsest_inverse_type = 0
+      integer :: coarsest_inverse_type = 1
       ! -pc_air_coarsest_poly_order
       integer :: coarsest_poly_order = 6
       ! -pc_air_coarsest_inverse_sparsity_order


### PR DESCRIPTION
Changed default option for coarsest grid inverse type in PCAIR. Previous behaviour can be restored with: -pc_air_coarsest_inverse_type power

The Arnoldi basis is more robust at scale without that big a performance difference.