### PR TITLE
Fix two bugs in make check. The first was the python check was not ro…

### DIFF
--- a/python/Makefile
+++ b/python/Makefile
@@ -37,9 +37,10 @@ export PYTHONPATH := $(if $(PYTHONPATH),$(PYTHONPATH):)$(PETSC_DIR)/$(PETSC_ARCH
 python:
 	$(PYTHON) setup.py build_ext --inplace
 
+.ONESHELL:
 run_tests:
-# Only run if the python module has been built (i.e. a .so file exists)
-ifneq ($(wildcard *.so),)
+   # Only run the rest of the recipe if the python module has been built and is importable
+	@$(PYTHON) -c "import pflare" 2>/dev/null || { echo 'Python check skipped (PFLARE Python module not built or not found)'; exit 0; }
 #
 	@echo ""
 	@echo "Test AIRG with GMRES polynomials for 2D finite difference stencil with Python"
@@ -63,23 +64,20 @@ ifneq ($(wildcard *.so),)
 	@echo "Test PMISR DDC CF splitting with Python"
 	$(PYTHON) ex2_cf_splitting.py
 	@echo "Test PMISR DDC CF splitting with Python in parallel"
-	$(MPIEXEC) -n 2 $(PYTHON) ex2_cf_splitting.py	
-else
-	@echo "Python tests skipped (PFLARE Python module has not been built)"
-endif		
+	$(MPIEXEC) -n 2 $(PYTHON) ex2_cf_splitting.py		
 
 # ~~~~~~~~~~~
 # ~~~~~~~~~~~
+.ONESHELL:
 run_check:
-# Only run if the python module has been built (i.e. a .so file exists)
-ifneq ($(wildcard *.so),)
+
+   # Only run the rest of the recipe if the python module has been built and is importable
+	@$(PYTHON) -c "import pflare" 2>/dev/null || { echo 'Python check skipped (PFLARE Python module not built or not found)'; exit 0; }
+
 	@echo "Python check"
-	@$(PYTHON) ex2.py -ksp_max_it 5 > /dev/null 2>&1 && echo "OK" || (echo "FAIL" && exit 1)
+	@$(PYTHON) ex2.py -ksp_max_it 5 && echo "OK" || (echo "FAIL" && exit 1)
 	@echo "Parallel Python check"
-	@$(MPIEXEC) -n 2 $(PYTHON) ex2.py -ksp_max_it 5 > /dev/null 2>&1 && echo "OK" || (echo "FAIL" && exit 1)	
-else
-	@echo "Python check skipped (PFLARE Python module has not been built)"
-endif	
+	@$(MPIEXEC) -n 2 $(PYTHON) ex2.py -ksp_max_it 5 && echo "OK" || (echo "FAIL" && exit 1)	
 
 # Cleanup
 clean::

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -546,15 +546,15 @@ run_check:
 #
 	@echo ""
 	@echo "Serial check"
-	@./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 > /dev/null 2>&1 && echo "OK" || (echo "FAIL" && exit 1)
+	@./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5  && echo "OK" || (echo "FAIL" && exit 1)
 	@echo "Parallel check"
-	@$(MPIEXEC) -n 2 ./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 > /dev/null 2>&1 && echo "OK" || (echo "FAIL" && exit 1)
+	@$(MPIEXEC) -n 2 ./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5  && echo "OK" || (echo "FAIL" && exit 1)
 ifeq ($(PETSC_HAVE_KOKKOS),1)
 # 
 	@echo "Serial KOKKOS check"
-	@./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -dm_vec_type kokkos -dm_mat_type aijkokkos > /dev/null 2>&1 && echo "OK" || (echo "FAIL" && exit 1)
+	@./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -dm_vec_type kokkos -dm_mat_type aijkokkos  && echo "OK" || (echo "FAIL" && exit 1)
 	@echo "Parallel KOKKOS check"
-	@$(MPIEXEC) -n 2 ./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -dm_vec_type kokkos -dm_mat_type aijkokkos > /dev/null 2>&1 && echo "OK" || (echo "FAIL" && exit 1)
+	@$(MPIEXEC) -n 2 ./adv_diff_2d -da_grid_x 25 -da_grid_y 25 -pc_type air -ksp_max_it 5 -dm_vec_type kokkos -dm_mat_type aijkokkos  && echo "OK" || (echo "FAIL" && exit 1)
 else	
 	@echo "KOKKOS check skipped (PETSc has not been configured with KOKKOS)"	
 


### PR DESCRIPTION
…bust enough and could trigger when the python module hadn't been built. The second was related to piping output in make check in certain environments that made it seem like tests failed when they didn't.