### PR TITLE
Fix Kokkos PMISR on nonsymmetric strength matrices, always symmetrize the strength matrix in PCAIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ tests/ilu_factors_kokkos
 tests/mat_diag
 tests/matrandom
 tests/matrandom_check_reset
+tests/pmisr_nonsymmetric
 tests/reuse_preconditioner
 tests/shell_block_apply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,10 @@ for earlier changes please see the git history.
   previously reachable through `-pc_air_symmetric`, which fed PMISR an
   unsymmetrized strength matrix, and was caught by the `PFLARE_KOKKOS_DEBUG`
   CPU/Kokkos cross-check. Since PCAIR itself now always symmetrizes, a new
-  `tests/pmisr_nonsymmetric` driver keeps this path covered, both through
-  direct `pmisr` calls on a structurally nonsymmetric strength matrix and
-  through `compute_cf_splitting` with `skip_symmetrize` true; both the
-  serial and parallel halo bugs abort the cross-check if reintroduced
+  `tests/pmisr_nonsymmetric` driver keeps this path covered by calling
+  `compute_cf_splitting` with `skip_symmetrize` true on a nonsymmetric
+  operator; both the serial and parallel halo bugs abort the cross-check
+  if reintroduced
 - New `PCMatApply` callback for PCPFLAREINV, so a block of right-hand sides is
   applied with a single sparse matrix by dense matrix product rather than
   PETSc's default loop over columns; on the GPU backends this keeps the whole

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ for earlier changes please see the git history.
 
 ## Unreleased
 
+- Behaviour change: PCAIR now always symmetrizes the strength matrix used to
+  compute the CF splitting. Previously `-pc_air_symmetric` skipped the
+  symmetrization, so the CF splittings and hence the results of existing runs
+  with that flag may change; `-pc_air_symmetric` now only controls whether the
+  prolongator is defined as R^T. The second argument of the standalone
+  `compute_cf_splitting` still controls the symmetrization with unchanged
+  polarity, but has been renamed from `symmetric` to `skip_symmetrize` to say
+  what it actually does - existing callers are unaffected other than the
+  Python keyword argument name
+- Fixed the Kokkos PMISR CF splitting producing different results to the CPU
+  implementation on structurally nonsymmetric strength matrices. This was
+  previously reachable through `-pc_air_symmetric`, which fed PMISR an
+  unsymmetrized strength matrix, and was caught by the `PFLARE_KOKKOS_DEBUG`
+  CPU/Kokkos cross-check. Since PCAIR itself now always symmetrizes, a new
+  `tests/pmisr_nonsymmetric` driver keeps this path covered, both through
+  direct `pmisr` calls on a structurally nonsymmetric strength matrix and
+  through `compute_cf_splitting` with `skip_symmetrize` true; both the
+  serial and parallel halo bugs abort the cross-check if reintroduced
 - New `PCMatApply` callback for PCPFLAREINV, so a block of right-hand sides is
   applied with a single sparse matrix by dense matrix product rather than
   PETSc's default loop over columns; on the GPU backends this keeps the whole

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,8 @@ export TEST_TARGETS = ex12f \
 		  adv_dg_upwind \
 		  ex6_two_airg \
 		  ilu_factors \
-		  reuse_preconditioner
+		  reuse_preconditioner \
+		  pmisr_nonsymmetric
 # Include kokkos examples
 ifeq ($(PETSC_HAVE_KOKKOS),1)
 export TEST_TARGETS := $(TEST_TARGETS) adv_1dk

--- a/docs/new_methods.md
+++ b/docs/new_methods.md
@@ -72,11 +72,11 @@ in Fortran:
      int :: max_luby_steps = -1
      ! PMISR DDC
      integer :: algorithm = CF_PMISR_DDC
-     ! Is the matrix symmetric?
-     logical :: symmetric = .FALSE.
+     ! Symmetrize the strength matrix
+     logical :: skip_symmetrize = .FALSE.
      
      call compute_cf_splitting(A, &
-           symmetric, &
+           skip_symmetrize, &
            strong_threshold, max_luby_steps, &
            algorithm, &
            ddc_its, &
@@ -96,11 +96,11 @@ or in C:
      int max_luby_steps = -1;
      // PMISR DDC
      int algorithm = CF_PMISR_DDC;
-     // Is the matrix symmetric?
-     int symmetric = 0;
+     // Symmetrize the strength matrix
+     int skip_symmetrize = 0;
 
      compute_cf_splitting(A, \
-         symmetric, \
+         skip_symmetrize, \
          strong_threshold, max_luby_steps, \
          algorithm, \
          ddc_its, \
@@ -119,11 +119,11 @@ or in Python with petsc4py:
      max_luby_steps = -1
      # PMISR DDC
      algorithm = pflare.CF_PMISR_DDC
-     # Is the matrix symmetric?
-     symmetric = False
+     # Symmetrize the strength matrix
+     skip_symmetrize = False
 
      [is_fine, is_coarse] = pflare.compute_cf_splitting(A, \
-           symmetric, \
+           skip_symmetrize, \
            strong_threshold, max_luby_steps, \
            algorithm, \
            ddc_its, \

--- a/include/pflare.h
+++ b/include/pflare.h
@@ -107,10 +107,12 @@ typedef enum {
 PETSC_EXTERN void PCRegister_PFLARE();
 
 /* Can call the CF splitting separate to everything
+   The second argument skips symmetrizing the strength matrix when nonzero
+   (ignored by the PMIS-based splittings, which always symmetrize)
    For CF_CR the strong threshold argument carries the target CR rate
    (just as it carries the target diagonal dominance ratio for CF_DIAG_DOM)
    and the max Luby steps, DDC iteration and DDC fraction arguments are ignored */
-PETSC_EXTERN void compute_cf_splitting(Mat, int, PetscReal, int, int, int, PetscReal, IS*, IS*);
+PETSC_EXTERN void compute_cf_splitting(Mat, int skip_symmetrize, PetscReal, int, int, int, PetscReal, IS*, IS*);
 PETSC_EXTERN void compute_diag_dom_submatrix(Mat, PetscReal, Mat*);
 
 /* Restrict input_mat onto output_mat's existing sparsity pattern.

--- a/python/ex2_cf_splitting.py
+++ b/python/ex2_cf_splitting.py
@@ -161,11 +161,11 @@ ddc_fraction = 0.1
 max_luby_steps = -1
 # PMISR DDC
 algorithm = pflare.CF_PMISR_DDC
-# Is the matrix symmetric?
-symmetric = False
+# Symmetrize the strength matrix
+skip_symmetrize = False
 
 [is_fine, is_coarse] = pflare.compute_cf_splitting(A,\
-      symmetric,\
+      skip_symmetrize,\
       strong_threshold, max_luby_steps,\
       algorithm,\
       ddc_its, \

--- a/python/pflare_defs.pyx
+++ b/python/pflare_defs.pyx
@@ -35,7 +35,7 @@ cdef extern:
 	# PetscInitializeFortran() first, which petsc4py does not, so the Fortran
 	# module block (MPIU_REAL etc.) is populated before the Fortran code runs.
 	# Aliased to distinct Cython names so they don't clash with the cpdef wrappers.
-	void compute_cf_splitting_cwrap "compute_cf_splitting" (PetscMat A, int symmetric_int, PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type, int ddc_its, PetscReal fraction_swap, PetscIS* is_fine, PetscIS* is_coarse)
+	void compute_cf_splitting_cwrap "compute_cf_splitting" (PetscMat A, int skip_symmetrize_int, PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type, int ddc_its, PetscReal fraction_swap, PetscIS* is_fine, PetscIS* is_coarse)
 	void compute_diag_dom_submatrix_cwrap "compute_diag_dom_submatrix" (PetscMat A, PetscReal max_dd_ratio, PetscMat *output_mat)
 
 	# -----------------------------------------------------------------------
@@ -191,12 +191,12 @@ cdef extern:
 cpdef py_PCRegister_PFLARE():
 	PCRegister_PFLARE()
 
-cpdef compute_cf_splitting(Mat A, bint symmetric, PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type, int ddc_its, PetscReal fraction_swap):
+cpdef compute_cf_splitting(Mat A, bint skip_symmetrize, PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type, int ddc_its, PetscReal fraction_swap):
 	cdef IS is_fine
 	cdef IS is_coarse
 	is_fine = IS()
 	is_coarse = IS()
-	compute_cf_splitting_cwrap(A.mat, symmetric, strong_threshold, max_luby_steps, cf_splitting_type, ddc_its, fraction_swap, &(is_fine.iset), &(is_coarse.iset))
+	compute_cf_splitting_cwrap(A.mat, skip_symmetrize, strong_threshold, max_luby_steps, cf_splitting_type, ddc_its, fraction_swap, &(is_fine.iset), &(is_coarse.iset))
 	return is_fine, is_coarse
 
 cpdef compute_diag_dom_submatrix(Mat A, PetscReal max_dd_ratio):

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -274,8 +274,10 @@ module air_mg_setup
             ! regardless of matrix_free_polys, as the ideal restrictor is
             ! always built from the assembled inverse and that is the binding
             ! constraint on the splitting quality)
+            ! Always symmetrize the strength matrix - the symmetric option
+            ! only controls whether the prolongator is defined as R^T
             call compute_cf_splitting(air_data%coarse_matrix(our_level), &
-                  air_data%options%symmetric, &
+                  .FALSE., &
                   air_data%options%strong_threshold, &
                   air_data%options%max_luby_steps, &
                   air_data%options%cf_splitting_type, &

--- a/src/CF_Splitting.F90
+++ b/src/CF_Splitting.F90
@@ -85,7 +85,8 @@ module cf_splitting
    
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, max_luby_steps, cf_splitting_type, cf_markers_local)
+   subroutine first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, &
+                  max_luby_steps, cf_splitting_type, cf_markers_local)
 
       ! Compute a strength matrix and then call the first pass of CF splitting
       ! skip_symmetrize skips symmetrizing the strength matrix for the PMISR DDC,
@@ -354,7 +355,8 @@ module cf_splitting
       else
 
          ! Generate the strength matrix and do the first pass CF splitting
-         call first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, max_luby_steps, cf_splitting_type, cf_markers_local)
+         call first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, &
+                  max_luby_steps, cf_splitting_type, cf_markers_local)
 
          ! Create the IS for the CF splittings
          if (need_intermediate_is) call create_cf_is(input_mat, cf_markers_local, is_fine, is_coarse)

--- a/src/CF_Splitting.F90
+++ b/src/CF_Splitting.F90
@@ -85,13 +85,16 @@ module cf_splitting
    
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine first_pass_splitting(input_mat, symmetric, strong_threshold, max_luby_steps, cf_splitting_type, cf_markers_local)
+   subroutine first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, max_luby_steps, cf_splitting_type, cf_markers_local)
 
-      ! Compute a symmetrized strength matrix and then call the first pass of CF splitting
+      ! Compute a strength matrix and then call the first pass of CF splitting
+      ! skip_symmetrize skips symmetrizing the strength matrix for the PMISR DDC,
+      ! diag dom and aggregation splittings - the PMIS-based splittings always
+      ! symmetrize as they are defined on the symmetrized graph
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: input_mat
-      logical, intent(in)                 :: symmetric
+      logical, intent(in)                 :: skip_symmetrize
       PetscReal, intent(in)                    :: strong_threshold
       integer, intent(in)                 :: max_luby_steps, cf_splitting_type
       integer, dimension(:), allocatable, intent(inout) :: cf_markers_local
@@ -139,19 +142,19 @@ module cf_splitting
          call generate_sabs(input_mat, strong_threshold, .TRUE., .FALSE., strength_mat)
 
       else if (cf_splitting_type == CF_DIAG_DOM) then
-         ! Only symmetrize if not already symmetric
-         
-         ! Tried to generate a strength matrix based on the relative size compared to the 
+         ! Symmetrize the strength matrix unless asked to skip it
+
+         ! Tried to generate a strength matrix based on the relative size compared to the
          ! diagonal, but it produces a worse initial coarsening when fed to PMISR, making
          ! the DDC cleanup take a lot more work
-         !call generate_sabs(input_mat, strong_threshold, .NOT. symmetric, .FALSE., strength_mat, &
+         !call generate_sabs(input_mat, strong_threshold, .NOT. skip_symmetrize, .FALSE., strength_mat, &
          !         allow_diag_strength = .TRUE.)
-         call generate_sabs(input_mat, strong_threshold, .NOT. symmetric, .FALSE., strength_mat)                   
+         call generate_sabs(input_mat, strong_threshold, .NOT. skip_symmetrize, .FALSE., strength_mat)
 
       ! PMISR DDC and Aggregation
-      else 
-         ! Only symmetrize if not already symmetric
-         call generate_sabs(input_mat, strong_threshold, .NOT. symmetric, .FALSE., strength_mat)         
+      else
+         ! Symmetrize the strength matrix unless asked to skip it
+         call generate_sabs(input_mat, strong_threshold, .NOT. skip_symmetrize, .FALSE., strength_mat)
       end if
 
       ! ~~~~~~~~~~~~
@@ -232,7 +235,7 @@ module cf_splitting
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine compute_cf_splitting(input_mat, symmetric, &
+   subroutine compute_cf_splitting(input_mat, skip_symmetrize, &
                      strong_threshold, max_luby_steps, &
                      cf_splitting_type, ddc_its, fraction_swap, &
                      is_fine, is_coarse, &
@@ -240,6 +243,9 @@ module cf_splitting
                      cr_diag_scale_polys)
 
       ! Computes a CF splitting and returns the F and C point ISs
+      ! skip_symmetrize skips symmetrizing the strength matrix (it does not
+      ! apply to the PMIS-based splittings, which are defined on the
+      ! symmetrized graph and always symmetrize)
       ! The optional cr_* arguments only apply to CF_CR and set the
       ! approximate inverse used as the CR relaxation - PCAIR passes its
       ! Aff inverse settings so the CR rate certifies the F-solve actually
@@ -249,7 +255,7 @@ module cf_splitting
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: input_mat
-      logical, intent(in)                 :: symmetric
+      logical, intent(in)                 :: skip_symmetrize
       PetscReal, intent(in)               :: strong_threshold
       integer, intent(in)                 :: max_luby_steps, cf_splitting_type, ddc_its
       PetscReal, intent(in)               :: fraction_swap
@@ -347,8 +353,8 @@ module cf_splitting
 
       else
 
-         ! Call the first pass CF splitting with a symmetrized strength matrix
-         call first_pass_splitting(input_mat, symmetric, strong_threshold, max_luby_steps, cf_splitting_type, cf_markers_local)
+         ! Generate the strength matrix and do the first pass CF splitting
+         call first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, max_luby_steps, cf_splitting_type, cf_markers_local)
 
          ! Create the IS for the CF splittings
          if (need_intermediate_is) call create_cf_is(input_mat, cf_markers_local, is_fine, is_coarse)

--- a/src/C_Fortran_Bindings.F90
+++ b/src/C_Fortran_Bindings.F90
@@ -249,32 +249,33 @@ module c_fortran_bindings
 
    !------------------------------------------------------------------------------------------------------------------------
 
-   subroutine compute_cf_splitting_c(input_mat_ptr, symmetric_int, &
+   subroutine compute_cf_splitting_c(input_mat_ptr, skip_symmetrize_int, &
          strong_threshold, max_luby_steps, &
          cf_splitting_type, ddc_its, fraction_swap, &
          is_fine_ptr, is_coarse_ptr) &
          bind(C,name='compute_cf_splitting_c')
 
       ! Computes a CF splitting
+      ! skip_symmetrize_int skips symmetrizing the strength matrix
 
       ! ~~~~~~~~
       integer(c_long_long), intent(in)       :: input_mat_ptr
-      integer(c_int), value, intent(in)      :: symmetric_int, max_luby_steps, cf_splitting_type, ddc_its
+      integer(c_int), value, intent(in)      :: skip_symmetrize_int, max_luby_steps, cf_splitting_type, ddc_its
       PetscReal, value, intent(in)           :: strong_threshold, fraction_swap
       integer(c_long_long), intent(inout)    :: is_fine_ptr, is_coarse_ptr
 
       type(tMat)  :: input_mat
       type(tIS)   :: is_fine, is_coarse
-      logical     :: symmetric = .FALSE.
-      ! ~~~~~~~~   
-      
+      logical     :: skip_symmetrize
+      ! ~~~~~~~~
+
       ! Now the input mat long long just gets copied into input_mat%v
       ! This works as the PETSc types are essentially just wrapped around
       ! pointers stored in %v
-      input_mat%v = input_mat_ptr  
-      
-      if (symmetric_int == 1) symmetric = .TRUE.
-      call compute_cf_splitting(input_mat, symmetric, &
+      input_mat%v = input_mat_ptr
+
+      skip_symmetrize = skip_symmetrize_int == 1
+      call compute_cf_splitting(input_mat, skip_symmetrize, &
                         strong_threshold, max_luby_steps, &
                         cf_splitting_type, ddc_its, fraction_swap, &
                         is_fine, is_coarse)

--- a/src/MatDiagDomSubmatrix.F90
+++ b/src/MatDiagDomSubmatrix.F90
@@ -32,7 +32,7 @@ module matdiagdomsubmatrix
       type(tIS) :: is_fine, is_coarse
       integer :: ddc_its, max_luby_steps, algorithm, errorcode
       PetscReal :: ddc_fraction
-      logical :: symmetric       
+      logical :: skip_symmetrize
  
       ! ~~~~~~  
 
@@ -50,13 +50,13 @@ module matdiagdomsubmatrix
      ! PMISR DDC where strength of connection is given by 
      ! |a_ij| .ge. max_dd_ratio |a_ii|
      algorithm = CF_DIAG_DOM
-     ! Assume asymmetric - still works for symmetric
-     symmetric = .FALSE.
+     ! Symmetrize the strength matrix
+     skip_symmetrize = .FALSE.
 
      ! Call the CF splitting
      ! We call with max_dd_ratio as the strong_threshold
      call compute_cf_splitting(input_mat, &
-           symmetric, &
+           skip_symmetrize, &
            max_dd_ratio, max_luby_steps, &
            algorithm, &
            ddc_its, &

--- a/src/PCAIR.c
+++ b/src/PCAIR.c
@@ -15,7 +15,7 @@
 PETSC_EXTERN void PCReset_AIR_Shell_c(PC *pc);
 PETSC_EXTERN void create_pc_air_data_c(void **pc_air_data);
 PETSC_EXTERN void create_pc_air_shell_c(void **pc_air_data, PC *pc);
-PETSC_EXTERN void compute_cf_splitting_c(Mat *input_mat, int symmetric_int,
+PETSC_EXTERN void compute_cf_splitting_c(Mat *input_mat, int skip_symmetrize_int,
    PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type,
    int ddc_its, PetscReal fraction_swap,
    IS *is_fine, IS *is_coarse);
@@ -228,7 +228,7 @@ static PetscErrorCode PCAIRCheckType(PC pc)
 // ~~~~~~~~~~~~~~~~~~~~~
 
 // CF splitting
-PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int symmetric_int,
+PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int skip_symmetrize_int,
    PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type,
    int ddc_its, PetscReal fraction_swap,
    IS *is_fine, IS *is_coarse)
@@ -237,7 +237,7 @@ PETSC_EXTERN void compute_cf_splitting(Mat input_mat, int symmetric_int,
    // so we have to have made sure this is called
    // Otherwise things like PETSC_NULL_INTEGER_ARRAY aren't defined
    PetscCallVoid(PetscInitializeFortran());
-   compute_cf_splitting_c(&input_mat, symmetric_int, strong_threshold,
+   compute_cf_splitting_c(&input_mat, skip_symmetrize_int, strong_threshold,
       max_luby_steps, cf_splitting_type, ddc_its, fraction_swap,
       is_fine, is_coarse);
 }

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -375,11 +375,14 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          // We've updated the values in cf_markers_nonlocal
          // Calling a reverse scatter add will then update the values of cf_markers_local
          // Reduce with a sum via VecScatter with ADD_VALUES, SCATTER_REVERSE
-         // Note the resulting marker arithmetic (cf_markers_d(i) + sum of neighbour marks)
-         // only stays consistent because the strength matrix passed in is structurally
-         // symmetric (S+S^T) - every neighbour of an in-set node was marked in the round
-         // that node was selected, so an in-set node can never receive marks later
-         // The nonsymmetric case is handled by pmisr_existing_measure_implicit_transpose_kokkos
+         // The reduction carries only the 0/1 neighbour marks, not the cf marker values
+         // themselves, so the sum is just a logical or of the marks (matching the
+         // MPI_LOR PetscSFReduce into assigned_local in the CPU version) and we merge
+         // it back below only into nodes that are still unassigned
+         // This keeps the same result if the strength matrix is not structurally
+         // symmetric, where an already assigned node (either in the set this loop or
+         // assigned in an earlier loop) can be a neighbour of an in-set node on
+         // another rank and hence receive a mark
          // Convert int → PetscScalar for the leaf (nonlocal) data
          {
             PetscScalarKokkosView leaf_scalar_d;
@@ -390,13 +393,13 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
             });
             PetscCallVoid(VecRestoreKokkosViewWrite(scatter_leaf_vec, &leaf_scalar_d));
          }
-         // Convert int → PetscScalar for the root (local) data
+         // The root (local) data only accumulates the neighbour marks, so start at zero
          {
             PetscScalarKokkosView root_scalar_d;
             PetscCallVoid(VecGetKokkosViewWrite(scatter_root_vec, &root_scalar_d));
             Kokkos::parallel_for(
                Kokkos::RangePolicy<>(exec, 0, local_rows), KOKKOS_LAMBDA(PetscInt i) {
-                  root_scalar_d(i) = (PetscScalar)cf_markers_d(i);
+                  root_scalar_d(i) = 0.0;
             });
             PetscCallVoid(VecRestoreKokkosViewWrite(scatter_root_vec, &root_scalar_d));
          }
@@ -434,13 +437,19 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
          // Complete reverse scatter before reading reduced root buffer.
          PetscCallVoid(VecScatterEnd(sf, scatter_leaf_vec, scatter_root_vec, ADD_VALUES, SCATTER_REVERSE));
 
-         // Convert PetscScalar → int back to cf_markers_d after End.
+         // Merge the reduced neighbour marks back into cf_markers_d after End.
+         // Any node that received a mark from a remote in-set node is now assigned,
+         // but only if it hasn't already been assigned - we must never overwrite the
+         // loops_through value of a node in the set this loop, or the marker of a node
+         // assigned in an earlier loop
+         // The CPU version leaves such nodes with a zero cf marker until the final
+         // "unassigned becomes C" pass, so assigning them as C here is equivalent
          {
             ConstPetscScalarKokkosView root_scalar_d;
             PetscCallVoid(VecGetKokkosView(scatter_root_vec, &root_scalar_d));
             Kokkos::parallel_for(
                Kokkos::RangePolicy<>(exec, 0, local_rows), KOKKOS_LAMBDA(PetscInt i) {
-                  cf_markers_d(i) = (int)root_scalar_d(i);
+                  if (root_scalar_d(i) > 0.0 && cf_markers_d(i) == 0) cf_markers_d(i) = 1;
             });
             PetscCallVoid(VecRestoreKokkosView(scatter_root_vec, &root_scalar_d));
          }
@@ -473,7 +482,17 @@ PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, co
                   Kokkos::parallel_for(
                      Kokkos::TeamThreadRange(t, ncols_local), [&](const PetscInt j) {
 
-                        Kokkos::atomic_store(&cf_markers_d(device_local_j[device_local_i[i] + j]), 1);
+                        // Needs to be atomic as may be set by many threads
+                        // Only assign neighbours that are still unassigned - if the
+                        // strength matrix is not structurally symmetric two neighbouring
+                        // nodes can be selected into the set in the same loop, and we
+                        // must not overwrite the loops_through value of an in-set node
+                        // (or the marker of a node assigned in an earlier loop)
+                        // This matches the CPU version, which tracks assignment in a
+                        // separate boolean and never touches an assigned node's marker
+                        // It also means the loops_through values are stable while this
+                        // kernel runs, so the guard above cannot race
+                        Kokkos::atomic_compare_exchange(&cf_markers_d(device_local_j[device_local_i[i] + j]), 0, 1);
                   });
                }
          });

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -618,7 +618,7 @@ run_tests_no_load_short_serial:
 #
 	@echo ""
 	@echo "Test the PMISR CF splitting directly on a structurally nonsymmetric strength matrix"
-	./pmisr_nonsymmetric -n 2500
+	./pmisr_nonsymmetric -n 700
 				
 #	 
 # ~~~~~~~~~~~~~~~~~~~~~~~	 
@@ -1042,8 +1042,8 @@ else
 #
 	@echo ""
 	@echo "Test the PMISR CF splitting directly on a structurally nonsymmetric strength matrix in parallel"
-	$(MPIEXEC) -n 2 ./pmisr_nonsymmetric -n 2500
-	$(MPIEXEC) -n 4 ./pmisr_nonsymmetric -n 2500
+	$(MPIEXEC) -n 2 ./pmisr_nonsymmetric -n 700
+	$(MPIEXEC) -n 4 ./pmisr_nonsymmetric -n 700
 
 #	 
 # ~~~~~~~~~~~~~~~~~~~~~~~	 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -615,6 +615,10 @@ run_tests_no_load_short_serial:
 	./adv_diff_cg_supg -pc_type air -ksp_type richardson -ksp_norm_type unpreconditioned -curved_velocity \
 	-ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -pc_air_a_lump -dm_plex_filename data/square_unstruc.msh \
 	-unit_velocity 0 -pc_air_diag_scale_polys 1 -pc_air_z_type lair -ksp_max_it 5	
+#
+	@echo ""
+	@echo "Test the PMISR CF splitting directly on a structurally nonsymmetric strength matrix"
+	./pmisr_nonsymmetric -n 2500
 				
 #	 
 # ~~~~~~~~~~~~~~~~~~~~~~~	 
@@ -1035,6 +1039,11 @@ else
 	$(MPIEXEC) -n 2 ./adv_diff_cg_supg -pc_type air -ksp_type richardson -ksp_norm_type unpreconditioned -curved_velocity \
 	-ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -pc_air_a_lump -dm_plex_filename data/square_unstruc.msh \
 	-unit_velocity 0 -pc_air_diag_scale_polys 1 -pc_air_z_type lair -ksp_max_it 5		
+#
+	@echo ""
+	@echo "Test the PMISR CF splitting directly on a structurally nonsymmetric strength matrix in parallel"
+	$(MPIEXEC) -n 2 ./pmisr_nonsymmetric -n 2500
+	$(MPIEXEC) -n 4 ./pmisr_nonsymmetric -n 2500
 
 #	 
 # ~~~~~~~~~~~~~~~~~~~~~~~	 

--- a/tests/ex6_cf_splitting.c
+++ b/tests/ex6_cf_splitting.c
@@ -216,11 +216,11 @@ int main(int argc,char **args)
  int max_luby_steps = -1;
  // PMISR DDC
  int algorithm = CF_PMISR_DDC;
- // Is the matrix symmetric?
- int symmetric = 0;
+ // Symmetrize the strength matrix
+ int skip_symmetrize = 0;
 
  compute_cf_splitting(A, \
-     symmetric, \
+     skip_symmetrize, \
      strong_threshold, max_luby_steps, \
      algorithm, \
      ddc_its, \
@@ -242,7 +242,7 @@ int main(int argc,char **args)
  algorithm = CF_DIAG_DOM;
 
  compute_cf_splitting(A, \
-     symmetric, \
+     skip_symmetrize, \
      strong_threshold, max_luby_steps, \
      algorithm, \
      ddc_its, \
@@ -267,7 +267,7 @@ int main(int argc,char **args)
  algorithm = CF_CR;
 
  compute_cf_splitting(A, \
-     symmetric, \
+     skip_symmetrize, \
      strong_threshold, max_luby_steps, \
      algorithm, \
      ddc_its, \

--- a/tests/pmisr_nonsymmetric.F90
+++ b/tests/pmisr_nonsymmetric.F90
@@ -1,0 +1,269 @@
+!
+!  Tests the pmisr CF splitting directly on a structurally nonsymmetric
+!  strength matrix.
+!
+!  PCAIR always symmetrizes the strength matrix it feeds to the first pass
+!  CF splitting, so the nonsymmetric input path through pmisr - and in
+!  particular the Kokkos kernel pmisr_existing_measure_cf_markers_kokkos -
+!  is not reachable through any PCAIR option.  This driver calls pmisr
+!  directly to keep that path covered.
+!
+!  The strength matrix here is the shape a wider 1D upwind stencil
+!  produces: an n point chain with unit entries, no diagonal, and row i
+!  holding entries in columns i-1 and i-2 only.  That is completely
+!  structurally nonsymmetric, and the in-degree of 2 means a corrupted
+!  marker in the halo exchange can sum into a wrong sign, which an
+!  in-degree 1 chain can hide.
+!
+!  The assertion that matters is not made here - it is made inside pmisr.
+!  Under PFLARE_KOKKOS_DEBUG=1 with -mat_type aijkokkos the wrapper runs
+!  both the Kokkos and the CPU implementations and aborts if the resulting
+!  cf markers differ.  In parallel the row i -> col i-1 entry of the first
+!  local row of every rank but the first crosses the rank boundary, so the
+!  MPI halo branch of the kernel is exercised as well as the serial one.
+!
+!  The checks below are only cheap sanity checks on the host result, and
+!  they are only made when the host cf markers are actually valid - the
+!  Kokkos pmisr leaves its result on the device and only copies it back to
+!  the host when the debug comparison asks for it.
+!
+!  The same nonsymmetric path is also exercised through the public
+!  compute_cf_splitting entry point with skip_symmetrize true.
+!
+      program main
+      use petscmat
+      use pmisr_module, only: pmisr
+      use cf_splitting, only: compute_cf_splitting, CF_PMIS, CF_PMISR_DDC
+      use pflare_parameters, only: C_POINT, F_POINT
+      use petsc_helper, only: kokkos_debug
+#include "petsc/finclude/petscmat.h"
+      implicit none
+
+      Mat            :: S
+      PetscInt       :: n, i, rstart, rend
+      PetscInt, parameter :: one = 1, two = 2
+      PetscScalar, parameter :: s_one = 1d0
+      PetscErrorCode :: ierr
+      PetscBool      :: flg
+      PetscMPIInt    :: rank
+      MatType        :: mat_type
+      logical        :: host_markers_valid, kokkos_mat
+
+      call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
+      call MPI_Comm_rank(PETSC_COMM_WORLD, rank, ierr)
+
+      n = 1000
+      call PetscOptionsGetInt(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-n', n, flg, ierr)
+
+      ! ~~~~~~~~~~~~
+      ! Build the strength matrix directly - unit entries, no diagonal and
+      ! row i has entries in columns i-1 and i-2 only (row 0 is empty)
+      ! MatSetFromOptions means -mat_type aijkokkos is honoured
+      ! ~~~~~~~~~~~~
+      call MatCreate(PETSC_COMM_WORLD, S, ierr)
+      call MatSetSizes(S, PETSC_DECIDE, PETSC_DECIDE, n, n, ierr)
+      call MatSetFromOptions(S, ierr)
+      call MatSeqAIJSetPreallocation(S, two, PETSC_NULL_INTEGER_ARRAY, ierr)
+      call MatMPIAIJSetPreallocation(S, two, PETSC_NULL_INTEGER_ARRAY, two, PETSC_NULL_INTEGER_ARRAY, ierr)
+      call MatSetUp(S, ierr)
+
+      call MatGetOwnershipRange(S, rstart, rend, ierr)
+      do i = rstart, rend-1
+         ! In parallel these entries are in the off-diagonal block for the
+         ! first local rows of every rank but the first
+         if (i > 0) call MatSetValue(S, i, i-one, s_one, INSERT_VALUES, ierr)
+         if (i > 1) call MatSetValue(S, i, i-two, s_one, INSERT_VALUES, ierr)
+      end do
+      call MatAssemblyBegin(S, MAT_FINAL_ASSEMBLY, ierr)
+      call MatAssemblyEnd(S, MAT_FINAL_ASSEMBLY, ierr)
+
+      ! ~~~~~~~~~~~~
+      ! The Kokkos pmisr leaves the cf markers on the device, so the host
+      ! copy is only meaningful if the debug comparison copied it back
+      ! ~~~~~~~~~~~~
+      kokkos_mat = .FALSE.
+      call MatGetType(S, mat_type, ierr)
+      if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
+            mat_type == MATAIJKOKKOS) kokkos_mat = .TRUE.
+
+      host_markers_valid = .TRUE.
+      if (kokkos_mat) host_markers_valid = kokkos_debug()
+
+      ! Negative max_luby_steps runs the Luby loop to completion
+      ! PMISR (pmis false) is the variant PCAIR uses
+      call do_splitting(S, .FALSE., host_markers_valid, "PMISR")
+      call do_splitting(S, .TRUE., host_markers_valid, "PMIS ")
+
+      ! ~~~~~~~~~~~~
+      ! With a Kokkos matrix pmisr leaves its result in a device view that
+      ! belongs to the library, and a Kokkos view that is still alive when
+      ! Kokkos is finalised aborts.  Nothing outside the library can free it
+      ! directly, but compute_cf_splitting owns that view for its whole
+      ! lifetime - it runs pmisr itself and then releases the device markers
+      ! once it has built its ISs - so one splitting here takes over the
+      ! markers our direct calls left behind and releases them
+      ! It also checks the normal CF splitting entry point still copes with a
+      ! matrix like this one
+      ! ~~~~~~~~~~~~
+      if (kokkos_mat) call release_device_cf_markers(S)
+
+      call MatDestroy(S, ierr)
+
+      ! Also go through the public compute_cf_splitting entry point with
+      ! skip_symmetrize true, which reaches pmisr with a nonsymmetric
+      ! strength matrix through the public API
+      call public_api_skip_symmetrize(n)
+
+      call PetscFinalize(ierr)
+
+      contains
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+      subroutine do_splitting(strength_mat, pmis, host_valid, label)
+
+         ! Calls pmisr and does some cheap sanity checks on the result
+
+         Mat, intent(in)      :: strength_mat
+         logical, intent(in)  :: pmis
+         logical, intent(in)  :: host_valid
+         character(len=*), intent(in) :: label
+
+         integer, allocatable, dimension(:) :: cf_markers
+         integer, parameter :: max_luby_steps = -1
+         PetscInt :: local_rows, local_cols
+         PetscInt :: n_c, n_f, n_bad
+         PetscInt :: n_c_global, n_f_global, n_bad_global
+         PetscErrorCode :: ierr_local
+         integer :: errorcode
+         MPIU_Comm :: comm
+
+         call PetscObjectGetComm(strength_mat, comm, ierr_local)
+
+         ! cf_markers is allocated inside pmisr, so it must come in unallocated
+         call pmisr(strength_mat, max_luby_steps, pmis, cf_markers)
+
+         call MatGetLocalSize(strength_mat, local_rows, local_cols, ierr_local)
+         if (size(cf_markers) /= local_rows) then
+            print *, "pmisr did not return one cf marker per local row"
+            error stop 1
+         end if
+
+         if (host_valid) then
+            n_c = count(cf_markers == C_POINT)
+            n_f = count(cf_markers == F_POINT)
+            n_bad = local_rows - n_c - n_f
+
+            ! Reduce so every rank makes the same pass/fail decision
+            call MPI_Allreduce(n_c, n_c_global, 1, MPIU_INTEGER, MPI_SUM, comm, errorcode)
+            call MPI_Allreduce(n_f, n_f_global, 1, MPIU_INTEGER, MPI_SUM, comm, errorcode)
+            call MPI_Allreduce(n_bad, n_bad_global, 1, MPIU_INTEGER, MPI_SUM, comm, errorcode)
+
+            if (n_bad_global /= 0) then
+               print *, "pmisr returned markers that are neither C nor F points"
+               error stop 1
+            end if
+            ! A chain of this size must produce some of both
+            if (n_c_global == 0 .OR. n_f_global == 0) then
+               print *, "pmisr returned an empty C or F set"
+               error stop 1
+            end if
+
+            if (rank == 0) print *, label, " nonsymmetric chain splitting: C points ", &
+                     n_c_global, " F points ", n_f_global
+         else
+            ! The markers are on the device and we have no way of getting at
+            ! them from here - pmisr itself has done the checking
+            if (rank == 0) print *, label, " nonsymmetric chain splitting: done on the device"
+         end if
+
+         deallocate(cf_markers)
+
+      end subroutine do_splitting
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+      subroutine release_device_cf_markers(strength_mat)
+
+         ! Runs one CF splitting through the normal entry point purely so the
+         ! device cf markers left behind by our direct pmisr calls are freed
+         ! by the library that allocated them
+         ! CF_PMIS is used because it skips the DDC pass, which would want
+         ! diagonal dominance ratios of a matrix that has no diagonal
+
+         Mat, intent(in) :: strength_mat
+
+         IS :: is_fine, is_coarse
+         PetscReal, parameter :: strong_threshold = 0.5d0, fraction_swap = 0d0
+         integer, parameter :: max_luby_steps = -1, ddc_its = 0
+         PetscErrorCode :: ierr_local
+
+         ! is_fine and is_coarse are created inside, exactly as PCAIR passes
+         ! them in - they must not be set to PETSC_NULL_IS first
+
+         ! Don't skip symmetrizing the strength matrix (though CF_PMIS
+         ! always symmetrizes regardless)
+         call compute_cf_splitting(strength_mat, .FALSE., &
+                  strong_threshold, max_luby_steps, &
+                  CF_PMIS, ddc_its, fraction_swap, &
+                  is_fine, is_coarse)
+
+         call ISDestroy(is_fine, ierr_local)
+         call ISDestroy(is_coarse, ierr_local)
+
+      end subroutine release_device_cf_markers
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+      subroutine public_api_skip_symmetrize(n_global)
+
+         ! Goes through the public compute_cf_splitting entry point with
+         ! skip_symmetrize true on a wide-stencil 1D upwind advection
+         ! operator (unit diagonal, -1 at columns i-1 and i-2) - the
+         ! strength matrix generated internally is then the same
+         ! nonsymmetric chain as the direct pmisr calls above use, so
+         ! under the kokkos debug comparison this covers the nonsymmetric
+         ! path through the public API - the CF splitting uses the
+         ! pmisr_ddc default that PCAIR uses
+
+         PetscInt, intent(in) :: n_global
+
+         Mat :: A
+         IS  :: is_fine, is_coarse
+         PetscInt :: rstart_l, rend_l, il
+         PetscInt, parameter :: three = 3
+         PetscReal, parameter :: strong_threshold = 0.5d0, fraction_swap = 0.1d0
+         integer, parameter :: max_luby_steps = -1, ddc_its = 1
+         PetscErrorCode :: ierr_local
+
+         call MatCreate(PETSC_COMM_WORLD, A, ierr_local)
+         call MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n_global, n_global, ierr_local)
+         call MatSetFromOptions(A, ierr_local)
+         call MatSeqAIJSetPreallocation(A, three, PETSC_NULL_INTEGER_ARRAY, ierr_local)
+         call MatMPIAIJSetPreallocation(A, three, PETSC_NULL_INTEGER_ARRAY, two, PETSC_NULL_INTEGER_ARRAY, ierr_local)
+         call MatSetUp(A, ierr_local)
+
+         call MatGetOwnershipRange(A, rstart_l, rend_l, ierr_local)
+         do il = rstart_l, rend_l-1
+            call MatSetValue(A, il, il, s_one, INSERT_VALUES, ierr_local)
+            if (il > 0) call MatSetValue(A, il, il-one, -s_one, INSERT_VALUES, ierr_local)
+            if (il > 1) call MatSetValue(A, il, il-two, -s_one, INSERT_VALUES, ierr_local)
+         end do
+         call MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY, ierr_local)
+         call MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY, ierr_local)
+
+         ! skip_symmetrize true - pmisr sees the nonsymmetric strength matrix
+         call compute_cf_splitting(A, .TRUE., &
+                  strong_threshold, max_luby_steps, &
+                  CF_PMISR_DDC, ddc_its, fraction_swap, &
+                  is_fine, is_coarse)
+
+         call ISDestroy(is_fine, ierr_local)
+         call ISDestroy(is_coarse, ierr_local)
+         call MatDestroy(A, ierr_local)
+
+         if (rank == 0) print *, "compute_cf_splitting with skip_symmetrize: done"
+
+      end subroutine public_api_skip_symmetrize
+
+      end program main

--- a/tests/pmisr_nonsymmetric.F90
+++ b/tests/pmisr_nonsymmetric.F90
@@ -1,269 +1,80 @@
 !
-!  Tests the pmisr CF splitting directly on a structurally nonsymmetric
-!  strength matrix.
+!  Tests the CF splitting on a structurally nonsymmetric strength
+!  matrix, by calling compute_cf_splitting with skip_symmetrize true.
+!  PCAIR always symmetrizes the strength matrix it builds, so this path
+!  is only reachable through compute_cf_splitting.
 !
-!  PCAIR always symmetrizes the strength matrix it feeds to the first pass
-!  CF splitting, so the nonsymmetric input path through pmisr - and in
-!  particular the Kokkos kernel pmisr_existing_measure_cf_markers_kokkos -
-!  is not reachable through any PCAIR option.  This driver calls pmisr
-!  directly to keep that path covered.
+!  There is no explicit check of the splitting here - the point of this
+!  test is running under PFLARE_KOKKOS_DEBUG=1 with -mat_type aijkokkos,
+!  where the CF splitting runs both the CPU and Kokkos implementations
+!  and aborts if they differ.
 !
-!  The strength matrix here is the shape a wider 1D upwind stencil
-!  produces: an n point chain with unit entries, no diagonal, and row i
-!  holding entries in columns i-1 and i-2 only.  That is completely
-!  structurally nonsymmetric, and the in-degree of 2 means a corrupted
-!  marker in the halo exchange can sum into a wrong sign, which an
-!  in-degree 1 chain can hide.
-!
-!  The assertion that matters is not made here - it is made inside pmisr.
-!  Under PFLARE_KOKKOS_DEBUG=1 with -mat_type aijkokkos the wrapper runs
-!  both the Kokkos and the CPU implementations and aborts if the resulting
-!  cf markers differ.  In parallel the row i -> col i-1 entry of the first
-!  local row of every rank but the first crosses the rank boundary, so the
-!  MPI halo branch of the kernel is exercised as well as the serial one.
-!
-!  The checks below are only cheap sanity checks on the host result, and
-!  they are only made when the host cf markers are actually valid - the
-!  Kokkos pmisr leaves its result on the device and only copies it back to
-!  the host when the debug comparison asks for it.
-!
-!  The same nonsymmetric path is also exercised through the public
-!  compute_cf_splitting entry point with skip_symmetrize true.
+!  The operator is a 1D chain (unit diagonal, -1 in columns i-2 and
+!  i+1), so with skip_symmetrize the strength matrix has no diagonal
+!  and row i holds entries in columns i-2 and i+1 only, which is
+!  structurally nonsymmetric.  Having strong connections in both
+!  directions matters in parallel: a node at a rank boundary can then
+!  be touched by the halo exchanges and by local updates in the same
+!  Luby round, which is what surfaces inconsistent halo handling.  A
+!  one-sided chain (all entries below the diagonal) cannot do that, and
+!  hides these bugs.
 !
       program main
+
       use petscmat
-      use pmisr_module, only: pmisr
-      use cf_splitting, only: compute_cf_splitting, CF_PMIS, CF_PMISR_DDC
-      use pflare_parameters, only: C_POINT, F_POINT
-      use petsc_helper, only: kokkos_debug
+      use cf_splitting, only: compute_cf_splitting, CF_PMISR_DDC
+
 #include "petsc/finclude/petscmat.h"
+
       implicit none
 
-      Mat            :: S
+      Mat            :: A
+      IS             :: is_fine, is_coarse
       PetscInt       :: n, i, rstart, rend
-      PetscInt, parameter :: one = 1, two = 2
+      PetscInt, parameter :: one = 1, two = 2, three = 3
       PetscScalar, parameter :: s_one = 1d0
+      PetscReal, parameter :: strong_threshold = 0.5d0, ddc_fraction = 0.1d0
+      integer, parameter  :: max_luby_steps = -1, ddc_its = 1
       PetscErrorCode :: ierr
       PetscBool      :: flg
-      PetscMPIInt    :: rank
-      MatType        :: mat_type
-      logical        :: host_markers_valid, kokkos_mat
 
       call PetscInitialize(PETSC_NULL_CHARACTER, ierr)
-      call MPI_Comm_rank(PETSC_COMM_WORLD, rank, ierr)
 
-      n = 1000
+      n = 700
       call PetscOptionsGetInt(PETSC_NULL_OPTIONS, PETSC_NULL_CHARACTER, '-n', n, flg, ierr)
 
       ! ~~~~~~~~~~~~
-      ! Build the strength matrix directly - unit entries, no diagonal and
-      ! row i has entries in columns i-1 and i-2 only (row 0 is empty)
+      ! Build the operator
       ! MatSetFromOptions means -mat_type aijkokkos is honoured
       ! ~~~~~~~~~~~~
-      call MatCreate(PETSC_COMM_WORLD, S, ierr)
-      call MatSetSizes(S, PETSC_DECIDE, PETSC_DECIDE, n, n, ierr)
-      call MatSetFromOptions(S, ierr)
-      call MatSeqAIJSetPreallocation(S, two, PETSC_NULL_INTEGER_ARRAY, ierr)
-      call MatMPIAIJSetPreallocation(S, two, PETSC_NULL_INTEGER_ARRAY, two, PETSC_NULL_INTEGER_ARRAY, ierr)
-      call MatSetUp(S, ierr)
+      call MatCreate(PETSC_COMM_WORLD, A, ierr)
+      call MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n, ierr)
+      call MatSetFromOptions(A, ierr)
+      call MatSeqAIJSetPreallocation(A, three, PETSC_NULL_INTEGER_ARRAY, ierr)
+      call MatMPIAIJSetPreallocation(A, three, PETSC_NULL_INTEGER_ARRAY, two, PETSC_NULL_INTEGER_ARRAY, ierr)
+      call MatSetUp(A, ierr)
 
-      call MatGetOwnershipRange(S, rstart, rend, ierr)
+      call MatGetOwnershipRange(A, rstart, rend, ierr)
       do i = rstart, rend-1
-         ! In parallel these entries are in the off-diagonal block for the
-         ! first local rows of every rank but the first
-         if (i > 0) call MatSetValue(S, i, i-one, s_one, INSERT_VALUES, ierr)
-         if (i > 1) call MatSetValue(S, i, i-two, s_one, INSERT_VALUES, ierr)
+         call MatSetValue(A, i, i, s_one, INSERT_VALUES, ierr)
+         if (i > 1) call MatSetValue(A, i, i-two, -s_one, INSERT_VALUES, ierr)
+         if (i < n-1) call MatSetValue(A, i, i+one, -s_one, INSERT_VALUES, ierr)
       end do
-      call MatAssemblyBegin(S, MAT_FINAL_ASSEMBLY, ierr)
-      call MatAssemblyEnd(S, MAT_FINAL_ASSEMBLY, ierr)
+      call MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY, ierr)
+      call MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY, ierr)
 
       ! ~~~~~~~~~~~~
-      ! The Kokkos pmisr leaves the cf markers on the device, so the host
-      ! copy is only meaningful if the debug comparison copied it back
+      ! The PMISR DDC splitting on the unsymmetrized strength matrix
       ! ~~~~~~~~~~~~
-      kokkos_mat = .FALSE.
-      call MatGetType(S, mat_type, ierr)
-      if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
-            mat_type == MATAIJKOKKOS) kokkos_mat = .TRUE.
+      call compute_cf_splitting(A, .TRUE., &
+               strong_threshold, max_luby_steps, &
+               CF_PMISR_DDC, ddc_its, ddc_fraction, &
+               is_fine, is_coarse)
 
-      host_markers_valid = .TRUE.
-      if (kokkos_mat) host_markers_valid = kokkos_debug()
-
-      ! Negative max_luby_steps runs the Luby loop to completion
-      ! PMISR (pmis false) is the variant PCAIR uses
-      call do_splitting(S, .FALSE., host_markers_valid, "PMISR")
-      call do_splitting(S, .TRUE., host_markers_valid, "PMIS ")
-
-      ! ~~~~~~~~~~~~
-      ! With a Kokkos matrix pmisr leaves its result in a device view that
-      ! belongs to the library, and a Kokkos view that is still alive when
-      ! Kokkos is finalised aborts.  Nothing outside the library can free it
-      ! directly, but compute_cf_splitting owns that view for its whole
-      ! lifetime - it runs pmisr itself and then releases the device markers
-      ! once it has built its ISs - so one splitting here takes over the
-      ! markers our direct calls left behind and releases them
-      ! It also checks the normal CF splitting entry point still copes with a
-      ! matrix like this one
-      ! ~~~~~~~~~~~~
-      if (kokkos_mat) call release_device_cf_markers(S)
-
-      call MatDestroy(S, ierr)
-
-      ! Also go through the public compute_cf_splitting entry point with
-      ! skip_symmetrize true, which reaches pmisr with a nonsymmetric
-      ! strength matrix through the public API
-      call public_api_skip_symmetrize(n)
+      call ISDestroy(is_fine, ierr)
+      call ISDestroy(is_coarse, ierr)
+      call MatDestroy(A, ierr)
 
       call PetscFinalize(ierr)
-
-      contains
-
-! -------------------------------------------------------------------------------------------------------------------------------
-
-      subroutine do_splitting(strength_mat, pmis, host_valid, label)
-
-         ! Calls pmisr and does some cheap sanity checks on the result
-
-         Mat, intent(in)      :: strength_mat
-         logical, intent(in)  :: pmis
-         logical, intent(in)  :: host_valid
-         character(len=*), intent(in) :: label
-
-         integer, allocatable, dimension(:) :: cf_markers
-         integer, parameter :: max_luby_steps = -1
-         PetscInt :: local_rows, local_cols
-         PetscInt :: n_c, n_f, n_bad
-         PetscInt :: n_c_global, n_f_global, n_bad_global
-         PetscErrorCode :: ierr_local
-         integer :: errorcode
-         MPIU_Comm :: comm
-
-         call PetscObjectGetComm(strength_mat, comm, ierr_local)
-
-         ! cf_markers is allocated inside pmisr, so it must come in unallocated
-         call pmisr(strength_mat, max_luby_steps, pmis, cf_markers)
-
-         call MatGetLocalSize(strength_mat, local_rows, local_cols, ierr_local)
-         if (size(cf_markers) /= local_rows) then
-            print *, "pmisr did not return one cf marker per local row"
-            error stop 1
-         end if
-
-         if (host_valid) then
-            n_c = count(cf_markers == C_POINT)
-            n_f = count(cf_markers == F_POINT)
-            n_bad = local_rows - n_c - n_f
-
-            ! Reduce so every rank makes the same pass/fail decision
-            call MPI_Allreduce(n_c, n_c_global, 1, MPIU_INTEGER, MPI_SUM, comm, errorcode)
-            call MPI_Allreduce(n_f, n_f_global, 1, MPIU_INTEGER, MPI_SUM, comm, errorcode)
-            call MPI_Allreduce(n_bad, n_bad_global, 1, MPIU_INTEGER, MPI_SUM, comm, errorcode)
-
-            if (n_bad_global /= 0) then
-               print *, "pmisr returned markers that are neither C nor F points"
-               error stop 1
-            end if
-            ! A chain of this size must produce some of both
-            if (n_c_global == 0 .OR. n_f_global == 0) then
-               print *, "pmisr returned an empty C or F set"
-               error stop 1
-            end if
-
-            if (rank == 0) print *, label, " nonsymmetric chain splitting: C points ", &
-                     n_c_global, " F points ", n_f_global
-         else
-            ! The markers are on the device and we have no way of getting at
-            ! them from here - pmisr itself has done the checking
-            if (rank == 0) print *, label, " nonsymmetric chain splitting: done on the device"
-         end if
-
-         deallocate(cf_markers)
-
-      end subroutine do_splitting
-
-! -------------------------------------------------------------------------------------------------------------------------------
-
-      subroutine release_device_cf_markers(strength_mat)
-
-         ! Runs one CF splitting through the normal entry point purely so the
-         ! device cf markers left behind by our direct pmisr calls are freed
-         ! by the library that allocated them
-         ! CF_PMIS is used because it skips the DDC pass, which would want
-         ! diagonal dominance ratios of a matrix that has no diagonal
-
-         Mat, intent(in) :: strength_mat
-
-         IS :: is_fine, is_coarse
-         PetscReal, parameter :: strong_threshold = 0.5d0, fraction_swap = 0d0
-         integer, parameter :: max_luby_steps = -1, ddc_its = 0
-         PetscErrorCode :: ierr_local
-
-         ! is_fine and is_coarse are created inside, exactly as PCAIR passes
-         ! them in - they must not be set to PETSC_NULL_IS first
-
-         ! Don't skip symmetrizing the strength matrix (though CF_PMIS
-         ! always symmetrizes regardless)
-         call compute_cf_splitting(strength_mat, .FALSE., &
-                  strong_threshold, max_luby_steps, &
-                  CF_PMIS, ddc_its, fraction_swap, &
-                  is_fine, is_coarse)
-
-         call ISDestroy(is_fine, ierr_local)
-         call ISDestroy(is_coarse, ierr_local)
-
-      end subroutine release_device_cf_markers
-
-! -------------------------------------------------------------------------------------------------------------------------------
-
-      subroutine public_api_skip_symmetrize(n_global)
-
-         ! Goes through the public compute_cf_splitting entry point with
-         ! skip_symmetrize true on a wide-stencil 1D upwind advection
-         ! operator (unit diagonal, -1 at columns i-1 and i-2) - the
-         ! strength matrix generated internally is then the same
-         ! nonsymmetric chain as the direct pmisr calls above use, so
-         ! under the kokkos debug comparison this covers the nonsymmetric
-         ! path through the public API - the CF splitting uses the
-         ! pmisr_ddc default that PCAIR uses
-
-         PetscInt, intent(in) :: n_global
-
-         Mat :: A
-         IS  :: is_fine, is_coarse
-         PetscInt :: rstart_l, rend_l, il
-         PetscInt, parameter :: three = 3
-         PetscReal, parameter :: strong_threshold = 0.5d0, fraction_swap = 0.1d0
-         integer, parameter :: max_luby_steps = -1, ddc_its = 1
-         PetscErrorCode :: ierr_local
-
-         call MatCreate(PETSC_COMM_WORLD, A, ierr_local)
-         call MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n_global, n_global, ierr_local)
-         call MatSetFromOptions(A, ierr_local)
-         call MatSeqAIJSetPreallocation(A, three, PETSC_NULL_INTEGER_ARRAY, ierr_local)
-         call MatMPIAIJSetPreallocation(A, three, PETSC_NULL_INTEGER_ARRAY, two, PETSC_NULL_INTEGER_ARRAY, ierr_local)
-         call MatSetUp(A, ierr_local)
-
-         call MatGetOwnershipRange(A, rstart_l, rend_l, ierr_local)
-         do il = rstart_l, rend_l-1
-            call MatSetValue(A, il, il, s_one, INSERT_VALUES, ierr_local)
-            if (il > 0) call MatSetValue(A, il, il-one, -s_one, INSERT_VALUES, ierr_local)
-            if (il > 1) call MatSetValue(A, il, il-two, -s_one, INSERT_VALUES, ierr_local)
-         end do
-         call MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY, ierr_local)
-         call MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY, ierr_local)
-
-         ! skip_symmetrize true - pmisr sees the nonsymmetric strength matrix
-         call compute_cf_splitting(A, .TRUE., &
-                  strong_threshold, max_luby_steps, &
-                  CF_PMISR_DDC, ddc_its, fraction_swap, &
-                  is_fine, is_coarse)
-
-         call ISDestroy(is_fine, ierr_local)
-         call ISDestroy(is_coarse, ierr_local)
-         call MatDestroy(A, ierr_local)
-
-         if (rank == 0) print *, "compute_cf_splitting with skip_symmetrize: done"
-
-      end subroutine public_api_skip_symmetrize
 
       end program main


### PR DESCRIPTION
## Summary

- Fixes the Kokkos PMISR CF splitting producing different results to the CPU implementation on structurally nonsymmetric strength matrices (repro: `./adv_1d -n 1000 -pc_type air -pc_air_symmetric` with `-mat_type aijkokkos` and `PFLARE_KOKKOS_DEBUG=1` aborted with "Kokkos and CPU versions of pmisr do not match")
  - Serial branch: the neighbour-marking `atomic_store(..., 1)` could overwrite the F marker of a node selected into the set in the same Luby round (possible only when the strength matrix is nonsymmetric); replaced with a compare-exchange that only assigns still-unassigned neighbours, matching the CPU's separate `assigned_local` bookkeeping
  - MPI branch: the ADD reverse scatter mixed cf marker values with neighbour marks, corrupting in-set/already-assigned nodes at rank boundaries (e.g. `-1 + 1 = 0`); the reduction now carries only the 0/1 marks and merges them back only into unassigned nodes (the analogue of the CPU's `MPI_LOR` reduce)
- Behaviour change: PCAIR now always symmetrizes the strength matrix used for the CF splitting; `-pc_air_symmetric` only controls whether the prolongator is defined as R^T. CF splittings of existing `-pc_air_symmetric` runs may change
- The second argument of the standalone `compute_cf_splitting` still controls the symmetrization with unchanged polarity, renamed `symmetric` → `skip_symmetrize` (only the Python keyword argument name is a visible change for existing callers)
- New `tests/pmisr_nonsymmetric` driver keeps the nonsymmetric path covered now that PCAIR no longer reaches it, using only the public `compute_cf_splitting` with `skip_symmetrize` true. The operator is a chain with -1 in columns i-2 and i+1, so the strength matrix is structurally nonsymmetric with strong connections in both directions - required so that rank-boundary nodes see halo and local updates in the same Luby round, which is what surfaces inconsistent halo handling (a one-sided chain hides the MPI bug). Runs serial and at 2/4 ranks in `tests_short`
- Also fixes a latent implicit-SAVE sticky flag in `compute_cf_splitting_c`

## Testing

- `make check` + `make tests_short`: plain CPU, `-mat_type aijkokkos -vec_type kokkos -dm_mat_type aijkokkos -dm_vec_type kokkos -on_error_abort`, and the same plus `PFLARE_KOKKOS_DEBUG=1` — all pass
- `adv_1d -pc_air_symmetric` and `pmisr_nonsymmetric` at 1/2/4 ranks under the debug cross-check — pass
- Fail-before/pass-after: reverting only the serial-branch compare-exchange makes the serial `pmisr_nonsymmetric` run abort with exit 16; reverting only the MPI-branch scatter fix makes the 2- and 4-rank runs abort with exit 16; with both fixes in place all runs pass
- `make python` could not be verified locally (pre-existing setuptools/`pyproject.toml` incompatibility in this environment, fails identically on main); the passing Kokkos CI jobs compile the renamed `.pyx` successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
