### PR TITLE
Simplify and tighten the constrain_z/constrain_w test options

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -675,16 +675,14 @@ run_tests_no_load_serial:
 	./adv_diff_fd -da_grid_x 100 -da_grid_y 100 \
 	 -u 0.816496580927726 -v 0.5773502691896258 -pc_type air \
 	 -ksp_type richardson -ksp_norm_type unpreconditioned \
-	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 60 \
-	 -pc_air_smooth_type ffc -pc_air_inverse_type power \
+	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 20 \
 	 -pc_air_cf_splitting_type pmis -pc_air_inverse_sparsity_order 2 \
 	 -pc_air_constrain_z -ksp_converged_reason
 	@echo "Test constrain w on non-grid-aligned advection with fast coarsening"
 	./adv_diff_fd -da_grid_x 100 -da_grid_y 100 \
 	 -u 0.816496580927726 -v 0.5773502691896258 -pc_type air \
 	 -ksp_type richardson -ksp_norm_type unpreconditioned \
-	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 60 \
-	 -pc_air_smooth_type ffc -pc_air_inverse_type power \
+	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 15 \
 	 -pc_air_cf_splitting_type pmis -pc_air_inverse_sparsity_order 2 \
 	 -pc_air_constrain_w -ksp_converged_reason
 	@echo "Test constrain z with a deep hierarchy where a coarse constraint vector collapses"
@@ -1168,8 +1166,7 @@ else
 	$(MPIEXEC) -n 2 ./adv_diff_fd -da_grid_x 100 -da_grid_y 100 \
 	 -u 0.816496580927726 -v 0.5773502691896258 -pc_type air \
 	 -ksp_type richardson -ksp_norm_type unpreconditioned \
-	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 60 \
-	 -pc_air_smooth_type ffc -pc_air_inverse_type power \
+	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 20 \
 	 -pc_air_cf_splitting_type pmis -pc_air_inverse_sparsity_order 2 \
 	 -pc_air_constrain_z -ksp_converged_reason
 	@echo "Test constrain z with a deep hierarchy where a coarse constraint vector collapses in parallel"
@@ -1241,7 +1238,7 @@ run_tests_medium_serial:
 		-u 0.816496580927726 -v 0.5773502691896258 -pc_type air \
 		-ksp_type richardson -ksp_norm_type unpreconditioned \
 		-ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -ksp_max_it 18 \
-		-pc_air_smooth_type ffc -pc_air_inverse_type power \
+		-pc_air_smooth_type ffc \
 		-pc_air_cf_splitting_type pmis -pc_air_inverse_sparsity_order 2 \
 		-pc_air_constrain_z -ksp_converged_reason; \
 	done


### PR DESCRIPTION
Follow-up to #267. Trims redundant options from the constraint tests added there and tightens their iteration caps.

## The three non-grid-aligned advection constraint tests

`-pc_air_smooth_type ffc` and `-pc_air_inverse_type power` are not needed — these tests discriminate via `DIVERGED_DTOL` at iteration 1 on unfixed code, so the cap and the smoother choice are not what makes them catch a regression. Running on the defaults (`ff`) is cheaper and slightly better:

| test | before (ffc, power) | after (ff, default) |
|---|---|---|
| `constrain_z` 100², serial | 18 | 17 |
| `constrain_w` 100², serial | 14 | 12 |
| `constrain_z` 100², `-n 2` | 17 | 17 |

Their `-ksp_max_it 60` was ~3.5x the actual count, so a large convergence regression would have passed silently. Pinned near the measured counts instead — 20 for the `constrain_z` pair, 15 for `constrain_w` — matching the convention of the exact-count `ex6f` constrain tests.

## The medium scaling sweep

Keeps `ffc`. That test exists to assert h-independence through an exact cap of 18, and on `ff` the count is **17/18/21** across 100²/200²/400² rather than flat, which breaks the 400² point. `-pc_air_inverse_type power` is inert there and is dropped.

## Testing

`make tests_search TEST_MATCH="-pc_air_constrain"` — all 13 matching commands pass, scaling sweep back to a flat 18/18/18. `make check` passes. `make tests_short` was not run locally; leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)