### PR TITLE
GPU tests: fixes from the first runs on Cirun + Vast.ai

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -19,6 +19,7 @@ runners:
     labels:
       - cirun-gpu-runner
     extra_config:
-      # Minimum disk (GB) and RAM (GB) of the host; the image alone is ~10GB
-      disk_space: 40
-      min_ram: 16
+      # Minimum disk (GB) and RAM (GB) of the host; the image alone is ~10GB.
+      # Kept low so the cheap single-GPU hosts are not filtered out.
+      disk_space: 30
+      min_ram: 8

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -90,10 +90,25 @@ jobs:
           # Don't leave the workflow token on a rented machine
           persist-credentials: false
 
-      # The step deliberately left out of the image build, as it needs a GPU
+      # The step deliberately left out of the image build, as it needs a GPU.
+      # make check compiles and runs the examples inside the PETSc tree and
+      # ignores errors, so check the tree is writable by the runner user first
+      # (the image makes it world-writable) and fail on any error in the output.
       - name: PETSc self-test
         if: ${{ !inputs.smoke_only }}
-        run: make -C "$PETSC_DIR" check
+        run: |
+          set -o pipefail
+          for d in "$PETSC_DIR/src/snes/tutorials" "$PETSC_DIR/$PETSC_ARCH/lib/petsc/conf"; do
+            if [ ! -w "$d" ]; then
+              echo "::error::$d is not writable by $(id -un); make check would silently do nothing"
+              exit 1
+            fi
+          done
+          make -C "$PETSC_DIR" check 2>&1 | tee check_output.log
+          if grep -Eq "Possible error|Permission denied|Error [0-9]+" check_output.log; then
+            echo "::error::PETSc make check reported errors (see above)"
+            exit 1
+          fi
 
       - name: Build PFLARE
         if: ${{ !inputs.smoke_only }}

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -42,20 +42,29 @@ jobs:
       # (not to the PETSc self-test or the Cython build)
       PFLARE_FLAGS: CFLAGS="-Wall -Werror -Wunused-result" CXXFLAGS="-Wall -Werror -Wunused-result -std=c++20" CPPFLAGS="-Wall -Werror -Wunused-result"
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          # Don't leave the workflow token on a rented machine
-          persist-credentials: false
-
-      - name: Set up PATH
+      # Cirun starts the runner as a separate user inside the container, and the
+      # session it inherits may not have HOME pointing at that user's home. Fix
+      # it before anything (actions/checkout stats $HOME/.gitconfig). Only a
+      # handful of variables are printed: Vast.ai injects secrets into the
+      # container environment and this log is public.
+      - name: Runner environment
         run: |
+          echo "user: $(id)"
+          echo "HOME=$HOME RUNNER_TEMP=$RUNNER_TEMP GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          passwd_home=$(getent passwd "$(id -u)" | cut -d: -f6)
+          echo "passwd home: $passwd_home"
+          if [ -n "$passwd_home" ] && [ "$passwd_home" != "$HOME" ]; then
+            echo "Overriding HOME=$HOME with $passwd_home for the rest of the job"
+            echo "HOME=$passwd_home" >> "$GITHUB_ENV"
+          fi
+          ls -ld "$HOME" "$passwd_home" "$RUNNER_TEMP" "$GITHUB_WORKSPACE" 2>&1 || true
           echo "$VIRTUAL_ENV/bin" >> "$GITHUB_PATH"
           echo "$PETSC_DIR/$PETSC_ARCH/bin" >> "$GITHUB_PATH"
           echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
 
       # Keep this step permanently: on a marketplace you want every log to say
-      # which card you actually got.
+      # which card you actually got. Runs before checkout so a smoke run does
+      # not depend on the repository.
       - name: Record hardware
         run: |
           set -e
@@ -73,6 +82,13 @@ jobs:
             echo "::error::GPU compute capability $got cannot run code built for $want"
             exit 1
           fi
+
+      - name: Checkout code
+        if: ${{ !inputs.smoke_only }}
+        uses: actions/checkout@v4
+        with:
+          # Don't leave the workflow token on a rented machine
+          persist-credentials: false
 
       # The step deliberately left out of the image build, as it needs a GPU
       - name: PETSc self-test


### PR DESCRIPTION
Follow-ups from the first real runs of the GPU workflow:

- Cirun runs the runner as user `runnerx` but the session has `HOME=/root`, which killed `actions/checkout`. A first step now sets `HOME` from passwd.
- The hardware step runs before checkout, and checkout is skipped in `smoke_only` runs.
- PETSc `make check` silently did nothing on the first run (root-owned tree, errors ignored, still printed "run successfully"). The image now makes the tree world-writable (CI_builds #4); the step checks writability up front and fails on any error in the output. Verified: ex19 with CUDA, ex3k with Kokkos Kernels, ex100, ex5f all genuinely run on the GPU (28s).
- Host disk/RAM minimums lowered to 30GB/8GB.

Full run timings on an RTX 3060: self-test 28s, PFLARE build 5.5min, tests fail at ~4min on the known `adv_1d_multi_rhs` PlaceArray issue (pending PETSc Kokkos MR), so the workflow stays red until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)