### PR TITLE
PCAIR: propagate the options prefix to the inner PCMG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ for earlier changes please see the git history.
 
 ## Unreleased
 
+- Fixed PCAIR not passing its options prefix down to its inner PCMG. The
+  `-mg_coarse_*` / `-mg_levels_*` options were read unprefixed by every PCAIR
+  in a program, and `-foo_mg_coarse_*` for a PCAIR with prefix `-foo_` was
+  silently ignored. The level KSPs now carry the PCAIR prefix, so a prefixed
+  PCAIR reads `-foo_mg_coarse_*` and no longer reads the unprefixed options
 - Behaviour change: PCAIR now always symmetrizes the strength matrix used to
   compute the CF splitting. Previously `-pc_air_symmetric` skipped the
   symmetrization, so the CF splittings and hence the results of existing runs

--- a/docs/options.md
+++ b/docs/options.md
@@ -86,7 +86,7 @@ All options can be set either through command line arguments or programmatically
 
 #### Coarse grid solver options
 
-By default the coarse grid is solved with one application of a polynomial approximate inverse, controlled by the ``-pc_air_coarsest_*`` options below. `PCAIR` is built on PETSc's `PCMG`, so the coarse grid `KSP`/`PC` can also be overridden with the standard PETSc ``-mg_coarse_*`` options. For example, ``-mg_coarse_pc_type lu`` uses a direct solve on the coarse grid, while ``-mg_coarse_ksp_type richardson -mg_coarse_ksp_max_it 5`` applies several iterations of the default polynomial coarse solver.
+By default the coarse grid is solved with one application of a polynomial approximate inverse, controlled by the ``-pc_air_coarsest_*`` options below. `PCAIR` is built on PETSc's `PCMG`, so the coarse grid `KSP`/`PC` can also be overridden with the standard PETSc ``-mg_coarse_*`` options. For example, ``-mg_coarse_pc_type lu`` uses a direct solve on the coarse grid, while ``-mg_coarse_ksp_type richardson -mg_coarse_ksp_max_it 5`` applies several iterations of the default polynomial coarse solver. These follow the options prefix of the `PCAIR` in the usual PETSc way: for a `PCAIR` (or its `KSP`) with prefix ``-foo_`` the coarse solver options are ``-foo_mg_coarse_*``, and the unprefixed ``-mg_coarse_*`` options are not read by it.
 
    | Command line  | Routine | Description | Default |
    | ------------- | -- | ------------- | --- |

--- a/src/C_Fortran_Bindings.F90
+++ b/src/C_Fortran_Bindings.F90
@@ -97,6 +97,27 @@ module c_fortran_bindings
 
    !------------------------------------------------------------------------------------------------------------------------
 
+   subroutine pcair_shell_get_pcmg_c(pc_ptr, pcmg_ptr) bind(C,name='pcair_shell_get_pcmg_c')
+
+      ! Returns the PCMG underneath our PCShell as a long long
+
+      ! ~~~~~~~~
+      integer(c_long_long), intent(in)  :: pc_ptr
+      integer(c_long_long), intent(out) :: pcmg_ptr
+
+      type(tPC)   :: pc
+      type(pc_air_multigrid_data), pointer :: pc_air_data => null()
+      PetscErrorCode :: ierr
+      ! ~~~~~~~~
+
+      pc%v = pc_ptr
+      call PCShellGetContext(pc, pc_air_data, ierr)
+      pcmg_ptr = pc_air_data%pcmg%v
+
+   end subroutine pcair_shell_get_pcmg_c
+
+   !------------------------------------------------------------------------------------------------------------------------
+
    subroutine pcair_shell_block_matapply_c(pc_ptr, x_ptr, y_ptr, applied_int, error_int) &
          bind(C,name='pcair_shell_block_matapply_c')
 

--- a/src/PCAIR.c
+++ b/src/PCAIR.c
@@ -16,6 +16,7 @@ PETSC_EXTERN void PCReset_AIR_Shell_c(PC *pc);
 PETSC_EXTERN void create_pc_air_data_c(void **pc_air_data);
 PETSC_EXTERN void create_pc_air_shell_c(void **pc_air_data, PC *pc);
 PETSC_EXTERN void pcair_shell_block_matapply_c(PC *pc, Mat *X, Mat *Y, int *applied, int *error_code);
+PETSC_EXTERN void pcair_shell_get_pcmg_c(PC *pc, PC *pcmg);
 PETSC_EXTERN void compute_cf_splitting_c(Mat *input_mat, int skip_symmetrize_int,
    PetscReal strong_threshold, int max_luby_steps, int cf_splitting_type,
    int ddc_its, PetscReal fraction_swap,
@@ -225,11 +226,23 @@ static PetscErrorCode PCSetUp_AIR_c(PC pc)
 {
    PetscFunctionBegin;
    PC *pc_air_shell = (PC *)pc->data;
+   PC pcmg;
+   const char *prefix;
 
    // The pc_air_shell doesn't have any operators yet
    // as they are not available yet in pccreate
    // so we have to set them
    PetscCall(PCSetOperators(*pc_air_shell, pc->mat, pc->pmat));
+
+   // Pass our options prefix down to the shell and the underlying PCMG
+   // PCMGSetLevels uses the prefix of the PCMG when it names the level KSPs
+   // and PCSetUp_MG then calls KSPSetFromOptions on them, so this is what
+   // makes -prefix_mg_coarse_* and -prefix_mg_levels_* reach this PCAIR only
+   // rather than the unprefixed -mg_coarse_* hitting every PCAIR
+   PetscCall(PCGetOptionsPrefix(pc, &prefix));
+   PetscCall(PCSetOptionsPrefix(*pc_air_shell, prefix));
+   pcair_shell_get_pcmg_c(pc_air_shell, &pcmg);
+   PetscCall(PCSetOptionsPrefix(pcmg, prefix));
 
    // Keep the shell's reusepreconditioner flag in sync - if the flag has
    // been unset after a frozen solve the shell must be allowed

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -104,7 +104,8 @@ run_tests_load_serial:
 #
 	@echo ""
 	@echo "Test two concurrent AIRG solves"
-	./ex6_two_airg -f data/mat_stream_2364
+	./ex6_two_airg -f data/mat_stream_2364 -air1_mg_coarse_ksp_type richardson -air1_mg_coarse_ksp_max_it 3 \
+	 -air2_mg_coarse_ksp_type richardson -air2_mg_coarse_ksp_max_it 2 -mg_coarse_ksp_max_it 5
 #
 	@echo ""
 	@echo "Test AIRG can solve triangle factors from ILU factorisations"
@@ -222,7 +223,8 @@ else
 	$(MPIEXEC) -n 2 ./ex6 -f data/mat_stream_2364 -pc_air_a_drop 1e-3 -pc_air_inverse_type power -pc_air_matrix_free_polys -ksp_max_it 5
 #
 	@echo "Test two concurrent AIRG solves in parallel"
-	$(MPIEXEC) -n 2 ./ex6_two_airg -f data/mat_stream_2364
+	$(MPIEXEC) -n 2 ./ex6_two_airg -f data/mat_stream_2364 -air1_mg_coarse_ksp_type richardson -air1_mg_coarse_ksp_max_it 3 \
+	 -air2_mg_coarse_ksp_type richardson -air2_mg_coarse_ksp_max_it 2 -mg_coarse_ksp_max_it 5
 #
 	@echo "Test AIRG can solve triangle factors from ILU factorisations in parallel"
 	$(MPIEXEC) -n 2 ./ilu_factors -f data/mat_stream_2364

--- a/tests/ex6_two_airg.c
+++ b/tests/ex6_two_airg.c
@@ -1,5 +1,8 @@
 static char help[] = "Reads a PETSc matrix and sets up two concurrent PCAIR\n\
 preconditioners on it, this checks the data structures are per PCAIR.\n\
+Also checks the options prefix of each PCAIR reaches its inner PCMG: any\n\
+-air1_mg_* / -air2_mg_* options given must be used, and unprefixed -mg_*\n\
+options must not be.\n\
 \n\
 Input arguments:\n\
   -f <input_file> : matrix to load (see $PETSC_DIR/share/petsc/datafiles/matrices)\n\n";
@@ -30,6 +33,45 @@ static PetscErrorCode BuildAIRKSP(MPI_Comm comm, Mat A, const char *prefix, Pets
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/* PCAIR must hand its options prefix down to its inner PCMG, whose level KSPs
+   are then named <prefix>mg_coarse_ / <prefix>mg_levels_N_ and read their
+   options in PCSetUp_MG. Any such prefixed option on the command line must
+   therefore have been used by the time the KSPs are set up, and the
+   unprefixed -mg_* options must have been ignored. Only options that are
+   actually present are checked, so the driver still runs bare. */
+static PetscErrorCode CheckPrefixedOption(const char *name, PetscBool expect_used, PetscBool *ok)
+{
+  PetscBool present, used;
+  PetscFunctionBeginUser;
+  /* PetscOptionsUsed matches the stored name, which has no leading dash. It
+     has to be asked first, as PetscOptionsHasName itself marks the option
+     as used */
+  PetscCall(PetscOptionsUsed(NULL, name + 1, &used));
+  PetscCall(PetscOptionsHasName(NULL, NULL, name, &present));
+  if (!present) PetscFunctionReturn(PETSC_SUCCESS);
+  if (used != expect_used) {
+    *ok = PETSC_FALSE;
+    PetscCall(PetscPrintf(PETSC_COMM_WORLD, "Option %s was %s\n", name, used ? "used but should not have been" : "not used"));
+  }
+  /* An unprefixed option is meant to go unused, drop it so PetscFinalize
+     doesn't warn about it */
+  if (!expect_used) PetscCall(PetscOptionsClearValue(NULL, name));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+static PetscErrorCode CheckOptionsPrefixes(PetscBool *ok)
+{
+  const char *prefixed[] = {"-air1_mg_coarse_ksp_type", "-air1_mg_coarse_ksp_max_it", "-air1_mg_coarse_pc_type",
+                            "-air2_mg_coarse_ksp_type", "-air2_mg_coarse_ksp_max_it", "-air2_mg_coarse_pc_type"};
+  const char *unprefixed[] = {"-mg_coarse_ksp_type", "-mg_coarse_ksp_max_it", "-mg_coarse_pc_type"};
+  size_t      i;
+  PetscFunctionBeginUser;
+  *ok = PETSC_TRUE;
+  for (i = 0; i < sizeof(prefixed) / sizeof(prefixed[0]); i++) PetscCall(CheckPrefixedOption(prefixed[i], PETSC_TRUE, ok));
+  for (i = 0; i < sizeof(unprefixed) / sizeof(unprefixed[0]); i++) PetscCall(CheckPrefixedOption(unprefixed[i], PETSC_FALSE, ok));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 int main(int argc, char **args)
 {
   Mat                A, A_diff_type;
@@ -42,6 +84,7 @@ int main(int argc, char **args)
   MatType            mtype, mtype_input;
   KSP                ksp1, ksp2;
   KSPConvergedReason reason1, reason2;
+  PetscBool          prefixes_ok;
   int                npe;
 
   PetscCall(PetscInitialize(&argc, &args, (char *)0, help));
@@ -105,6 +148,10 @@ int main(int argc, char **args)
   PetscCall(BuildAIRKSP(PETSC_COMM_WORLD, A, "air1_", 0.3, &ksp1));
   PetscCall(BuildAIRKSP(PETSC_COMM_WORLD, A, "air2_", 0.8, &ksp2));
 
+  /* Both hierarchies are built, so the prefixed -airN_mg_* options have been
+     read by now if the prefix made it down to the inner PCMGs */
+  PetscCall(CheckOptionsPrefixes(&prefixes_ok));
+
   PetscCall(KSPSolve(ksp1, b, x1));
   PetscCall(KSPGetConvergedReason(ksp1, &reason1));
 
@@ -113,10 +160,10 @@ int main(int argc, char **args)
   PetscCall(KSPGetConvergedReason(ksp2, &reason2));
 
   PetscCall(PetscPrintf(PETSC_COMM_WORLD,
-                        "ksp1 reason = %d, ksp2 reason = %d\n",
-                        (int)reason1, (int)reason2));
+                        "ksp1 reason = %d, ksp2 reason = %d, options prefixes %s\n",
+                        (int)reason1, (int)reason2, prefixes_ok ? "ok" : "NOT propagated"));
 
-  int exit_code = (reason1 >= 0 && reason2 >= 0) ? 0 : 1;
+  int exit_code = (reason1 >= 0 && reason2 >= 0 && prefixes_ok) ? 0 : 1;
 
   PetscCall(KSPDestroy(&ksp1));
   PetscCall(KSPDestroy(&ksp2));


### PR DESCRIPTION
## Summary
- PCAIR never set an options prefix on its inner PCShell or PCMG, so `PCMGSetLevels` named every level KSP with the bare `mg_coarse_` / `mg_levels_N_` prefix. The unprefixed `-mg_coarse_*` options hit every PCAIR in a program, and `-foo_mg_coarse_*` for a PCAIR with prefix `-foo_` was silently ignored, contrary to `docs/options.md`.
- `PCSetUp_AIR_c` now copies the PCAIR prefix onto the shell and the PCMG before the hierarchy is built. Reaching the PCMG from C needed a small new Fortran binding, `pcair_shell_get_pcmg_c`. `PCSetFromOptions` is deliberately not called on the PCMG, so a prefixed `-foo_pc_type air` cannot recurse into it.
- `docs/options.md` states the prefix rule; `CHANGELOG.md` has an entry. This is a behaviour change: a prefixed PCAIR that relied on unprefixed `-mg_coarse_*` must now use the prefixed form.

## Test
`tests/ex6_two_airg` checks, after both hierarchies are built, that every present `-air1_mg_coarse_*` / `-air2_mg_coarse_*` option was consumed and that the unprefixed `-mg_coarse_*` options were not. The Makefile lines pass distinct coarse Richardson settings to each PCAIR plus an unprefixed decoy. Without the C fix the test fails with all four prefixed options unused.

Verified: `make check`, `make tests_short` and the `ex6_two_airg` load lines (serial and 2 ranks) all pass with no compile warnings. Kokkos code is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
