### PR TITLE
Move device cf markers off process-wide Kokkos globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ for earlier changes please see the git history.
 
 ## Unreleased
 
+- Fixed the Kokkos CF splitting keeping the device cf markers and diagonal
+  dominance ratios shared by `pmisr` and `ddc` in process-wide globals, so two
+  PCAIRs setting up concurrently would overwrite each other's markers. They
+  now live in a per-`compute_cf_splitting` context behind an opaque handle,
+  as the per-level IS views already did
 - Behaviour change: PCAIR now always symmetrizes the strength matrix used to
   compute the CF splitting. Previously `-pc_air_symmetric` skipped the
   symmetrization, so the CF splittings and hence the results of existing runs

--- a/docs/dev/kokkos.md
+++ b/docs/dev/kokkos.md
@@ -4,6 +4,7 @@ Conventions
 - A Fortran file `src/X.F90` has its GPU/threaded sibling `src/Xk.kokkos.cxx` (trailing `k` on the stem; the `.kokkos.cxx` suffix triggers PETSc's Kokkos build rules). Existing pairs include `PMISR_Modulek`, `Grid_Transferk`, `Gmres_Polyk`, `Gmres_Poly_Newtonk`, `SAI_Zk`, `DDC_Modulek`, `MatDiagDomk`, `Device_Datak`, `PETSc_Helperk`, `VecISCopyLocalk`.
 - Kernels are exported as `PETSC_INTERN void <snake_case>_kokkos(...)` and called from Fortran through ISO-C interfaces in `src/C_PETSc_Interfaces.F90` / `src/C_Fortran_Bindings.F90`. Shared typedefs/helpers live in `include/kokkos_helper.hpp`.
 - Build constraints: C++20; CI compiles with `-Wall -Werror -Wunused-result`.
+- No file-scope Kokkos state: two PCAIRs can set up or apply concurrently, so anything that outlives one kernel call lives in a context behind an opaque handle threaded through the Fortran call chain as a `type(c_ptr)` (`VecISCopyLocalKokkosCtx` on `air_data%kokkos_is_views_handle` for the per-level IS views; `CFMarkersKokkosCtx`, owned by `compute_cf_splitting`, for the device cf markers and diag-dom ratios shared by `pmisr`/`ddc`).
 - Kokkos has a hard 20MB limit on level-1 team scratch memory. Row-wise systems that can exceed it must fall back to a sparse/global-memory formulation (see `SAI_Zk.kokkos.cxx` and commit e49d5ec for the pattern).
 
 Debug-compare mode (`PFLARE_KOKKOS_DEBUG=1`)

--- a/include/kokkos_helper.hpp
+++ b/include/kokkos_helper.hpp
@@ -38,11 +38,9 @@ using KokkosCsrMatrix = KokkosSparse::CrsMatrix<PetscScalar, PetscInt, DefaultMe
 
 PETSC_INTERN void mat_duplicate_copy_plus_diag_kokkos(Mat *, int, Mat *);
 PETSC_INTERN void rewrite_j_global_to_local(PetscInt, PetscInt&, PetscIntKokkosView, PetscInt**);
-PETSC_INTERN void create_cf_is_device_kokkos(Mat *input_mat, const int match_cf, PetscIntKokkosView &is_local_d);
+PETSC_INTERN void create_cf_is_device_kokkos(void *handle, Mat *input_mat, const int match_cf, PetscIntKokkosView &is_local_d);
 PETSC_INTERN void pmisr_existing_measure_cf_markers_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int);
 PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscScalarKokkosView &measure_local_d, intKokkosView &cf_markers_d, const int zero_measure_c_point_int);
-PETSC_INTERN void copy_diag_dom_ratio_d2h(PetscReal *diag_dom_ratio_local);
-PETSC_INTERN void delete_device_diag_dom_ratio();
 
 // Per-PCAIR IS views (fine/coarse per multigrid level) live behind an opaque
 // handle owned by the air_data on the Fortran side; see VecISCopyLocalk for
@@ -51,8 +49,28 @@ PETSC_INTERN void delete_device_diag_dom_ratio();
 // returning a C++ Kokkos View. Callers are all C++ (.kokkos.cxx).
 PETSC_VISIBILITY_INTERNAL PetscIntKokkosView VecISCopyLocal_kokkos_get_view(void *handle, int our_level, int fine_int);
 
-extern intKokkosView cf_markers_local_d;
-extern PetscScalarKokkosView diag_dom_ratio_local_d;
+// Per-CF-splitting device storage: the cf markers on a given level (kept on
+// the device between the pmisr and ddc calls to save host round-trips) and the
+// fine-point diagonal dominance ratios the ddc uses. These used to be
+// file-scope globals in Device_Datak.kokkos.cxx, so two PCAIR instances setting
+// up concurrently would overwrite each other's markers (the same hazard as the
+// per-level IS views, see VecISCopyLocalKokkosCtx). The context is created by
+// pmisr_kokkos, owned as an opaque c_ptr by compute_cf_splitting on the Fortran
+// side, threaded through every kokkos call that needs it and destroyed by
+// destroy_cf_markers_kokkos.
+struct CFMarkersKokkosCtx {
+   // Be careful these aren't petsc ints
+   intKokkosView cf_markers_local_d;
+   PetscScalarKokkosView diag_dom_ratio_local_d;
+};
+
+// Cast an opaque handle back to its context. A null handle means a device
+// routine that needs the cf markers ran before pmisr_kokkos created them
+static inline CFMarkersKokkosCtx *cf_markers_kokkos_ctx(void *handle)
+{
+   PetscCheckAbort(handle, PETSC_COMM_SELF, PETSC_ERR_ARG_NULL, "Null device cf markers handle - pmisr_kokkos has not been called");
+   return static_cast<CFMarkersKokkosCtx *>(handle);
+}
 
 // ~~~~~~~~~~~~~~~~~~
 // Some custom reductions we use 

--- a/src/CF_Splitting.F90
+++ b/src/CF_Splitting.F90
@@ -1,5 +1,6 @@
 module cf_splitting
 
+   use iso_c_binding, only: c_ptr, c_null_ptr
    use petscmat
    use pflare_parameters, only: C_POINT, F_POINT, PFLARE_CR_MAX_ITS, &
             PFLARE_CR_POLY_ORDER, PFLAREINV_ARNOLDI
@@ -7,7 +8,7 @@ module cf_splitting
    use ddc_module, only: ddc
    use cr_splitting, only: cr_pass
    use sabs, only: generate_sabs
-   use c_petsc_interfaces, only: create_cf_is_kokkos, delete_device_cf_markers, delete_device_diag_dom_ratio
+   use c_petsc_interfaces, only: create_cf_is_kokkos, destroy_cf_markers_kokkos
    use aggregation, only: generate_serial_aggregation
    use petsc_helper, only: MatAXPYWrapper, MatSetAllValues, kokkos_debug, remove_small_from_sparse
 
@@ -86,12 +87,14 @@ module cf_splitting
 ! -------------------------------------------------------------------------------------------------------------------------------
 
    subroutine first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, &
-                  max_luby_steps, cf_splitting_type, cf_markers_local)
+                  max_luby_steps, cf_splitting_type, cf_markers_local, cf_markers_handle)
 
       ! Compute a strength matrix and then call the first pass of CF splitting
       ! skip_symmetrize skips symmetrizing the strength matrix for the PMISR DDC,
       ! diag dom and aggregation splittings - the PMIS-based splittings always
       ! symmetrize as they are defined on the symmetrized graph
+      ! On the device the pmisr leaves the cf markers in the device context
+      ! behind cf_markers_handle
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: input_mat
@@ -99,6 +102,7 @@ module cf_splitting
       PetscReal, intent(in)                    :: strong_threshold
       integer, intent(in)                 :: max_luby_steps, cf_splitting_type
       integer, dimension(:), allocatable, intent(inout) :: cf_markers_local
+      type(c_ptr), intent(inout)          :: cf_markers_handle
 
       ! Local
       PetscInt :: global_row_start, global_row_end_plus_one, i_loc
@@ -165,18 +169,18 @@ module cf_splitting
       ! PMISR
       if (cf_splitting_type == CF_PMISR_DDC .OR. cf_splitting_type == CF_DIAG_DOM) then
 
-         call pmisr(strength_mat, max_luby_steps, .FALSE., cf_markers_local)
+         call pmisr(strength_mat, max_luby_steps, .FALSE., cf_markers_local, cf_markers_handle)
 
       ! Distance 1 PMIS
       else if (cf_splitting_type == CF_PMIS) then
 
-         call pmisr(strength_mat, max_luby_steps, .TRUE., cf_markers_local)
+         call pmisr(strength_mat, max_luby_steps, .TRUE., cf_markers_local, cf_markers_handle)
 
       ! Distance 2 PMIS
       else if (cf_splitting_type == CF_PMIS_DIST2) then
 
          ! As we have generated S'S + S for the strength matrix, this will do distance 2 PMIS
-         call pmisr(strength_mat, max_luby_steps, .TRUE., cf_markers_local)
+         call pmisr(strength_mat, max_luby_steps, .TRUE., cf_markers_local, cf_markers_handle)
 
       ! PMIS on boundary nodes then processor local aggregation
       else if (cf_splitting_type == CF_PMIS_AGG) then
@@ -185,7 +189,7 @@ module cf_splitting
          if (comm_size /= 1) then
 
             ! Do distance 1 PMIS
-            call pmisr(strength_mat, max_luby_steps, .TRUE., cf_markers_local)
+            call pmisr(strength_mat, max_luby_steps, .TRUE., cf_markers_local, cf_markers_handle)
 
             ! Get the sequential part of the matrix
             call MatMPIAIJGetSeqAIJ(strength_mat, Ad, Ao, colmap, ierr) 
@@ -267,6 +271,11 @@ module cf_splitting
 
       PetscErrorCode :: ierr
       integer, dimension(:), allocatable, target :: cf_markers_local
+      ! Opaque handle to the device copy of cf_markers_local (and the diag dom
+      ! ratios) used by the Kokkos pmisr and ddc, see CFMarkersKokkosCtx in
+      ! kokkos_helper.hpp. Owned by this routine so that concurrent CF splittings
+      ! (eg two PCAIRs setting up) don't share device storage
+      type(c_ptr) :: cf_markers_handle
       integer :: its, ddc_its_max
       logical :: need_intermediate_is
       PetscReal :: max_dd_ratio_achieved, cr_rate_achieved
@@ -281,6 +290,9 @@ module cf_splitting
 #endif       
 
       ! ~~~~~~  
+
+      ! Created by pmisr if we're on the device, destroyed at the end
+      cf_markers_handle = c_null_ptr
 
       ! In Kokkos the DDC and PMISR do everything on the device
       ! that means we don't need to create intermediate is_fine and is_coarse ISs
@@ -356,7 +368,7 @@ module cf_splitting
 
          ! Generate the strength matrix and do the first pass CF splitting
          call first_pass_splitting(input_mat, skip_symmetrize, strong_threshold, &
-                  max_luby_steps, cf_splitting_type, cf_markers_local)
+                  max_luby_steps, cf_splitting_type, cf_markers_local, cf_markers_handle)
 
          ! Create the IS for the CF splittings
          if (need_intermediate_is) call create_cf_is(input_mat, cf_markers_local, is_fine, is_coarse)
@@ -379,7 +391,8 @@ module cf_splitting
             ! (or the equivalent device cf_markers, is_fine is ignored if on the device)
             max_dd_ratio_achieved = 0d0
             if (cf_splitting_type == CF_DIAG_DOM) max_dd_ratio_achieved = strong_threshold
-            call ddc(input_mat, is_fine, fraction_swap, max_dd_ratio_achieved, cf_markers_local)
+            call ddc(input_mat, is_fine, fraction_swap, max_dd_ratio_achieved, cf_markers_local, &
+                     cf_markers_handle)
 
             ! If we did anything in our ddc second pass and hence need to rebuild
             ! the is_fine and is_coarse
@@ -409,14 +422,6 @@ module cf_splitting
       if (mat_type == MATMPIAIJKOKKOS .OR. mat_type == MATSEQAIJKOKKOS .OR. &
             mat_type == MATAIJKOKKOS) then
 
-         ! The initial pmis will be on the device, so need to destroy
-         ! Intermediate ISs are created in that case
-         if (cf_splitting_type == CF_PMIS_AGG) then
-            ! Destroys the device cf_markers_local
-            call delete_device_cf_markers()
-            call delete_device_diag_dom_ratio()
-         end if
-      
          ! Aggregation is not on the device at all, and CR never creates
          ! device cf_markers (its host ISs are already the final answer)
          if (cf_splitting_type /= CF_AGG .AND. cf_splitting_type /= CF_PMIS_AGG .AND. &
@@ -427,7 +432,7 @@ module cf_splitting
             is_coarse_array = is_coarse_kokkos%v
 
             ! Create the host is_fine and is_coarse based on device cf_markers
-            call create_cf_is_kokkos(A_array, is_fine_array, is_coarse_array)  
+            call create_cf_is_kokkos(cf_markers_handle, A_array, is_fine_array, is_coarse_array)
             is_fine_kokkos%v = is_fine_array
             is_coarse_kokkos%v = is_coarse_array         
             
@@ -454,11 +459,12 @@ module cf_splitting
                is_fine = is_fine_kokkos
                is_coarse = is_coarse_kokkos
             end if
-
-            ! Destroys the device cf_markers_local
-            call delete_device_cf_markers()
-            call delete_device_diag_dom_ratio()
          end if
+
+         ! Destroys the device cf_markers_local and diag dom ratios
+         ! For pmis agg the initial pmis was on the device so this is needed, 
+         ! for agg and cr nothing was created on the device and this does nothing
+         call destroy_cf_markers_kokkos(cf_markers_handle)
 
       end if    
 #endif       

--- a/src/C_PETSc_Interfaces.F90
+++ b/src/C_PETSc_Interfaces.F90
@@ -214,9 +214,10 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine create_cf_is_kokkos(A_array, index_fine, index_coarse) &
+      subroutine create_cf_is_kokkos(handle, A_array, index_fine, index_coarse) &
          bind(c, name="create_cf_is_kokkos")
          use iso_c_binding
+         type(c_ptr), value :: handle
          integer(c_long_long) :: A_array
          integer(c_long_long) :: index_fine
          integer(c_long_long) :: index_coarse
@@ -226,9 +227,10 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local, zero_meaure_c_point_int) &
+      subroutine pmisr_kokkos(handle, A_array, max_luby_steps, pmis_int, measure_local, zero_meaure_c_point_int) &
          bind(c, name="pmisr_kokkos")
          use iso_c_binding
+         type(c_ptr) :: handle
          integer(c_long_long) :: A_array
          type(c_ptr), value :: measure_local
          integer(c_int), value :: max_luby_steps, pmis_int, zero_meaure_c_point_int
@@ -238,9 +240,10 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine MatDiagDomRatio_kokkos(A_array, max_dd_ratio_achieved, local_rows_aff) &
+      subroutine MatDiagDomRatio_kokkos(handle, A_array, max_dd_ratio_achieved, local_rows_aff) &
          bind(c, name="MatDiagDomRatio_kokkos")
          use iso_c_binding
+         type(c_ptr), value :: handle
          integer(c_long_long) :: A_array
          PetscReal :: max_dd_ratio_achieved
          PetscInt :: local_rows_aff
@@ -250,10 +253,11 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine ddc_kokkos(A_array, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, Aff_array, &
+      subroutine ddc_kokkos(handle, A_array, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, Aff_array, &
             random_numbers_ptr) &
          bind(c, name="ddc_kokkos")
          use iso_c_binding
+         type(c_ptr), value :: handle
          integer(c_long_long) :: A_array
          PetscReal, value :: fraction_swap
          PetscReal, value :: max_dd_ratio
@@ -266,9 +270,10 @@ module c_petsc_interfaces
    
    interface   
       
-      subroutine copy_cf_markers_d2h(cf_markers_local) &
+      subroutine copy_cf_markers_d2h(handle, cf_markers_local) &
          bind(c, name="copy_cf_markers_d2h")
          use iso_c_binding
+         type(c_ptr), value :: handle
          type(c_ptr), value :: cf_markers_local
       end subroutine copy_cf_markers_d2h         
  
@@ -276,9 +281,10 @@ module c_petsc_interfaces
    
    interface   
       
-      subroutine copy_diag_dom_ratio_d2h(diag_dom_ratio_local) &
+      subroutine copy_diag_dom_ratio_d2h(handle, diag_dom_ratio_local) &
          bind(c, name="copy_diag_dom_ratio_d2h")
          use iso_c_binding
+         type(c_ptr), value :: handle
          type(c_ptr), value :: diag_dom_ratio_local
       end subroutine copy_diag_dom_ratio_d2h
  
@@ -286,19 +292,13 @@ module c_petsc_interfaces
 
    interface   
       
-      subroutine delete_device_cf_markers() &
-         bind(c, name="delete_device_cf_markers")
+      ! Destroys the device cf markers and diag dom ratio behind handle
+      ! (created by pmisr_kokkos) and sets it to c_null_ptr
+      subroutine destroy_cf_markers_kokkos(handle) &
+         bind(c, name="destroy_cf_markers_kokkos")
          use iso_c_binding
-      end subroutine delete_device_cf_markers         
- 
-   end interface       
-
-   interface   
-      
-      subroutine delete_device_diag_dom_ratio() &
-         bind(c, name="delete_device_diag_dom_ratio")
-         use iso_c_binding
-      end subroutine delete_device_diag_dom_ratio
+         type(c_ptr) :: handle
+      end subroutine destroy_cf_markers_kokkos
  
    end interface
 

--- a/src/DDC_Module.F90
+++ b/src/DDC_Module.F90
@@ -19,7 +19,7 @@ module ddc_module
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine ddc(input_mat, is_fine, fraction_swap, max_dd_ratio, cf_markers_local)
+   subroutine ddc(input_mat, is_fine, fraction_swap, max_dd_ratio, cf_markers_local, cf_markers_handle)
 
       ! Second pass diagonal dominance cleanup 
       ! Flips the F definitions to C based on least diagonally dominant local rows
@@ -28,6 +28,8 @@ module ddc_module
       !  for swapping C to F based on row-wise diagonal dominance (ie alpha_diag)
       ! If fraction_swap > 0 it uses fraction_swap as the local fraction of worst C points to swap to F
       !  though it won't hit that fraction exactly as we bin the diag dom ratios for speed, it will be close to the fraction
+      ! On the device this modifies the cf markers in the device context behind
+      ! cf_markers_handle (created by pmisr) rather than cf_markers_local
 
       ! ~~~~~~
       type(tMat), target, intent(in)      :: input_mat
@@ -35,6 +37,7 @@ module ddc_module
       PetscReal, intent(in)               :: fraction_swap
       PetscReal, intent(inout)            :: max_dd_ratio
       integer, dimension(:), allocatable, target, intent(inout) :: cf_markers_local
+      type(c_ptr), intent(inout)          :: cf_markers_handle
 
       type(tMat) :: Aff_ddc
       PetscErrorCode :: ierr
@@ -73,7 +76,8 @@ module ddc_module
       ! or stored in a device copy for kokkos
       ! max_dd_ratio_achieved is always returned and is the max diag dom ratio across
       ! all ranks
-      call MatDiagDomRatio(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+      call MatDiagDomRatio(input_mat, is_fine, cf_markers_local, cf_markers_handle, &
+               diag_dom_ratio, max_dd_ratio_achieved)
 
       ! If we have hit the required diagonal dominance ratio, return
       if (trigger_dd_ratio_compute_local .AND. max_dd_ratio_achieved < max_dd_ratio) then
@@ -119,7 +123,7 @@ module ddc_module
          if (trigger_dd_ratio_compute_local) then
 
             ! Create the host is_fine and is_coarse based on device cf_markers
-            call create_cf_is_kokkos(A_array, is_fine_array, is_coarse_array)
+            call create_cf_is_kokkos(cf_markers_handle, A_array, is_fine_array, is_coarse_array)
             is_fine_temp%v = is_fine_array
             is_coarse_temp%v = is_coarse_array
 
@@ -141,15 +145,15 @@ module ddc_module
          end if
 
          ! Modifies the existing device cf_markers created by the pmisr
-         call ddc_kokkos(A_array, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, Aff_array, &
-            random_numbers_ptr)
+         call ddc_kokkos(cf_markers_handle, A_array, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
+            Aff_array, random_numbers_ptr)
 
          ! If debugging do a comparison between CPU and Kokkos results
          if (kokkos_debug()) then
 
             ! Kokkos DDC by default now doesn't copy back to the host, as any subsequent ddc calls
             ! use the existing device data
-            call copy_cf_markers_d2h(cf_markers_local_ptr)
+            call copy_cf_markers_d2h(cf_markers_handle, cf_markers_local_ptr)
             if (trigger_dd_ratio_compute_local) then
                call ddc_cpu(input_mat, is_fine, fraction_swap, max_dd_ratio, max_dd_ratio_achieved, &
                   diag_dom_ratio, cf_markers_local_two, &

--- a/src/DDC_Modulek.kokkos.cxx
+++ b/src/DDC_Modulek.kokkos.cxx
@@ -2,25 +2,25 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 
-// The definition of the device copy of the cf markers on a given level 
-// is stored in Device_Datak.kokkos.cxx and imported as extern from 
-// kokkos_helper.hpp
+// The device copy of the cf markers on a given level lives in the
+// CFMarkersKokkosCtx behind handle, see kokkos_helper.hpp
 
 //------------------------------------------------------------------------------------------------------------------------
 
-// ddc cleanup but on the device - uses the global variable cf_markers_local_d
+// ddc cleanup but on the device - modifies the device cf_markers_local_d in handle
 // This no longer copies back to the host pointer cf_markers_local at the end
-// You have to explicitly call copy_cf_markers_d2h(cf_markers_local) to do this
-PETSC_INTERN void ddc_kokkos(Mat *input_mat, const PetscReal fraction_swap, const PetscReal max_dd_ratio, const PetscReal max_dd_ratio_achieved, Mat *aff, PetscReal *random_numbers)
+// You have to explicitly call copy_cf_markers_d2h(handle, cf_markers_local) to do this
+PETSC_INTERN void ddc_kokkos(void *handle, Mat *input_mat, const PetscReal fraction_swap, const PetscReal max_dd_ratio, const PetscReal max_dd_ratio_achieved, Mat *aff, PetscReal *random_numbers)
 {
-   // Can't use the global directly within the parallel 
+   // Shallow copies of the context's views for use within the parallel 
    // regions on the device
-   intKokkosView cf_markers_d = cf_markers_local_d;  
-   PetscScalarKokkosView diag_dom_ratio_d = diag_dom_ratio_local_d;
+   CFMarkersKokkosCtx *ctx = cf_markers_kokkos_ctx(handle);
+   intKokkosView cf_markers_d = ctx->cf_markers_local_d;  
+   PetscScalarKokkosView diag_dom_ratio_d = ctx->diag_dom_ratio_local_d;
    PetscIntKokkosView is_fine_local_d;
 
    const int match_cf = -1; // F_POINT == -1
-   create_cf_is_device_kokkos(input_mat, match_cf, is_fine_local_d);
+   create_cf_is_device_kokkos(handle, input_mat, match_cf, is_fine_local_d);
    PetscInt local_rows_aff = is_fine_local_d.extent(0);
 
    bool trigger_dd_ratio_compute = max_dd_ratio > 0;

--- a/src/Device_Datak.kokkos.cxx
+++ b/src/Device_Datak.kokkos.cxx
@@ -2,17 +2,32 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 
-// This is a device copy of the cf markers on a given level
-// to save having to copy it to/from the host between pmisr and ddc calls
-intKokkosView cf_markers_local_d;
-// Device copy of local fine-point diagonal-dominance ratios for DDC
-PetscScalarKokkosView diag_dom_ratio_local_d;
+// The device copy of the cf markers on a given level (to save having to copy
+// it to/from the host between pmisr and ddc calls) and of the local fine-point
+// diagonal-dominance ratios for DDC live in a CFMarkersKokkosCtx (see
+// kokkos_helper.hpp) behind the opaque handle passed in from Fortran
 
 //------------------------------------------------------------------------------------------------------------------------
 
-// Copy the global cf_markers_local_d back to the host
-PETSC_INTERN void copy_cf_markers_d2h(int *cf_markers_local)
+// Destroys the device cf markers context. handle is a pointer to a void*
+// (Fortran c_ptr by ref); sets it to NULL on exit so the caller's c_ptr
+// becomes c_null_ptr. Deleting the context releases its views
+PETSC_INTERN void destroy_cf_markers_kokkos(void **handle)
 {
+   if (!handle || !*handle) return;
+   auto *ctx = static_cast<CFMarkersKokkosCtx *>(*handle);
+   delete ctx;
+   *handle = nullptr;
+
+   return;
+}
+
+//------------------------------------------------------------------------------------------------------------------------
+
+// Copy the device cf_markers_local_d back to the host
+PETSC_INTERN void copy_cf_markers_d2h(void *handle, int *cf_markers_local)
+{
+   intKokkosView cf_markers_local_d = cf_markers_kokkos_ctx(handle)->cf_markers_local_d;
    // Host wrapper for cf_markers_local
    intKokkosViewHost cf_markers_local_h(cf_markers_local, cf_markers_local_d.extent(0));
 
@@ -28,9 +43,10 @@ PETSC_INTERN void copy_cf_markers_d2h(int *cf_markers_local)
 
 //------------------------------------------------------------------------------------------------------------------------
 
-// Copy the global diag_dom_ratio_local_d back to the host
-PETSC_INTERN void copy_diag_dom_ratio_d2h(PetscReal *diag_dom_ratio_local)
+// Copy the device diag_dom_ratio_local_d back to the host
+PETSC_INTERN void copy_diag_dom_ratio_d2h(void *handle, PetscReal *diag_dom_ratio_local)
 {
+   PetscScalarKokkosView diag_dom_ratio_local_d = cf_markers_kokkos_ctx(handle)->diag_dom_ratio_local_d;
    // Host wrapper for diag_dom_ratio_local
    PetscScalarKokkosViewHost diag_dom_ratio_h(diag_dom_ratio_local, diag_dom_ratio_local_d.extent(0));
 
@@ -46,40 +62,16 @@ PETSC_INTERN void copy_diag_dom_ratio_d2h(PetscReal *diag_dom_ratio_local)
 
 //------------------------------------------------------------------------------------------------------------------------
 
-// Delete the global cf_markers_local_d
-PETSC_INTERN void delete_device_cf_markers()
-{
-   // Delete the device view - this assigns an empty view
-   // and hence the old view has its ref counter decremented
-   cf_markers_local_d = intKokkosView();
-
-   return;
-}
-
-//------------------------------------------------------------------------------------------------------------------------
-
-// Delete the global diag_dom_ratio_local_d
-PETSC_INTERN void delete_device_diag_dom_ratio()
-{
-   // Delete the device view - this assigns an empty view
-   // and hence the old view has its ref counter decremented
-   diag_dom_ratio_local_d = PetscScalarKokkosView();
-
-   return;
-}
-
-//------------------------------------------------------------------------------------------------------------------------
-
-// Creates the device local indices for F or C points based on the global cf_markers_local_d
-PETSC_INTERN void create_cf_is_device_kokkos(Mat *input_mat, const int match_cf, PetscIntKokkosView &is_local_d)
+// Creates the device local indices for F or C points based on the device cf_markers_local_d
+PETSC_INTERN void create_cf_is_device_kokkos(void *handle, Mat *input_mat, const int match_cf, PetscIntKokkosView &is_local_d)
 {
    PetscInt local_rows, local_cols;
    PetscCallVoid(MatGetLocalSize(*input_mat, &local_rows, &local_cols));
    auto exec = PetscGetKokkosExecutionSpace();
 
-   // Can't use the global directly within the parallel
+   // Shallow copy of the context's view for use within the parallel
    // regions on the device
-   intKokkosView cf_markers_d = cf_markers_local_d;
+   intKokkosView cf_markers_d = cf_markers_kokkos_ctx(handle)->cf_markers_local_d;
 
    // ~~~~~~~~~~~~
    // Get the F point local indices from cf_markers_local_d
@@ -129,8 +121,8 @@ PETSC_INTERN void create_cf_is_device_kokkos(Mat *input_mat, const int match_cf,
 
 //------------------------------------------------------------------------------------------------------------------------
 
-// Creates the host IS is_fine and is_coarse based on the global cf_markers_local_d
-PETSC_INTERN void create_cf_is_kokkos(Mat *input_mat, IS *is_fine, IS *is_coarse)
+// Creates the host IS is_fine and is_coarse based on the device cf_markers_local_d
+PETSC_INTERN void create_cf_is_kokkos(void *handle, Mat *input_mat, IS *is_fine, IS *is_coarse)
 {
    PetscIntKokkosView is_fine_local_d, is_coarse_local_d;
    MPI_Comm MPI_COMM_MATRIX;
@@ -138,11 +130,11 @@ PETSC_INTERN void create_cf_is_kokkos(Mat *input_mat, IS *is_fine, IS *is_coarse
 
    // Create the local f point indices
    const int match_fine = -1; // F_POINT == -1
-   create_cf_is_device_kokkos(input_mat, match_fine, is_fine_local_d);
+   create_cf_is_device_kokkos(handle, input_mat, match_fine, is_fine_local_d);
 
    // Create the local C point indices
    const int match_coarse = 1; // C_POINT == 1
-   create_cf_is_device_kokkos(input_mat, match_coarse, is_coarse_local_d);
+   create_cf_is_device_kokkos(handle, input_mat, match_coarse, is_coarse_local_d);
 
    // Now convert them back to global indices
    PetscInt global_row_start, global_row_end_plus_one;

--- a/src/MatDiagDom.F90
+++ b/src/MatDiagDom.F90
@@ -20,15 +20,19 @@ module matdiagdom
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine MatDiagDomRatio(input_mat, is_fine, cf_markers_local, diag_dom_ratio, max_dd_ratio_achieved)
+   subroutine MatDiagDomRatio(input_mat, is_fine, cf_markers_local, cf_markers_handle, &
+                  diag_dom_ratio, max_dd_ratio_achieved)
 
       ! Wrapper for diagonal-dominance ratio computation.
       ! Chooses Kokkos or CPU implementation and optionally compares the
       ! resulting host ratios in debug mode.
+      ! On the device the cf markers are read from and the ratios are
+      ! stored in the device context behind cf_markers_handle (created by pmisr)
 
       type(tMat), target, intent(in)      :: input_mat
       type(tIS), intent(in)               :: is_fine
       integer, dimension(:), intent(in)   :: cf_markers_local
+      type(c_ptr), intent(inout)          :: cf_markers_handle
       PetscReal, dimension(:), allocatable, target, intent(out) :: diag_dom_ratio
       PetscReal, intent(out)              :: max_dd_ratio_achieved
 
@@ -53,13 +57,13 @@ module matdiagdom
          local_rows_aff_kokkos = 0
          max_dd_ratio_achieved = 0d0
 
-         call MatDiagDomRatio_kokkos(A_array, max_dd_ratio_achieved, local_rows_aff_kokkos)
+         call MatDiagDomRatio_kokkos(cf_markers_handle, A_array, max_dd_ratio_achieved, local_rows_aff_kokkos)
 
          if (kokkos_debug()) then
             allocate(diag_dom_ratio(local_rows_aff_kokkos))
             if (local_rows_aff_kokkos > 0) then
                diag_dom_ratio_ptr = c_loc(diag_dom_ratio)
-               call copy_diag_dom_ratio_d2h(diag_dom_ratio_ptr)
+               call copy_diag_dom_ratio_d2h(cf_markers_handle, diag_dom_ratio_ptr)
             end if
 
             call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, &
@@ -87,6 +91,8 @@ module matdiagdom
                                   diag_dom_ratio, max_dd_ratio_achieved)
       end if
 #else
+      ! There are no device cf markers or ratios without Kokkos
+      cf_markers_handle = c_null_ptr
       call MatDiagDomRatio_cpu(input_mat, is_fine, cf_markers_local, &
                                diag_dom_ratio, max_dd_ratio_achieved)
 #endif

--- a/src/MatDiagDomk.kokkos.cxx
+++ b/src/MatDiagDomk.kokkos.cxx
@@ -2,15 +2,15 @@
 #include "kokkos_helper.hpp"
 #include <iostream>
 
-// The definition of the device copy of the cf markers on a given level 
-// is stored in Device_Datak.kokkos.cxx and imported as extern from 
-// kokkos_helper.hpp
+// The device copy of the cf markers on a given level lives in the
+// CFMarkersKokkosCtx behind handle, see kokkos_helper.hpp
 
 //------------------------------------------------------------------------------------------------------------------------
 
-// Computes the diagonal dominance ratio of the input matrix over fine points in global variable cf_markers_local_d
+// Computes the diagonal dominance ratio of the input matrix over fine points in the device cf_markers_local_d
+// The ratios are stored on the device in diag_dom_ratio_local_d in handle for the ddc
 // This code is very similar to MatCreateSubMatrix_kokkos
-PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio_achieved, PetscInt *local_rows_aff)
+PETSC_INTERN void MatDiagDomRatio_kokkos(void *handle, Mat *input_mat, PetscReal *max_dd_ratio_achieved, PetscInt *local_rows_aff)
 {
    PetscInt local_rows, local_cols;
 
@@ -40,9 +40,10 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
       mat_local = *input_mat;
    }
 
-   // Can't use the global directly within the parallel 
+   // Shallow copy of the context's view for use within the parallel 
    // regions on the device
-   intKokkosView cf_markers_d = cf_markers_local_d;   
+   CFMarkersKokkosCtx *ctx = cf_markers_kokkos_ctx(handle);
+   intKokkosView cf_markers_d = ctx->cf_markers_local_d;   
    intKokkosView cf_markers_nonlocal_d;
    Vec scatter_root_vec = NULL;
    PetscIntKokkosView is_fine_local_d;
@@ -52,13 +53,13 @@ PETSC_INTERN void MatDiagDomRatio_kokkos(Mat *input_mat, PetscReal *max_dd_ratio
    // Get the F point local indices from cf_markers_local_d
    // ~~~~~~~~~~~~
    const int match_cf = -1; // F_POINT == -1
-   create_cf_is_device_kokkos(input_mat, match_cf, is_fine_local_d);
+   create_cf_is_device_kokkos(handle, input_mat, match_cf, is_fine_local_d);
    PetscInt local_rows_row = is_fine_local_d.extent(0);
    *local_rows_aff = local_rows_row;
 
-   // Create device memory for the diag_dom_ratio
-   diag_dom_ratio_local_d = PetscScalarKokkosView("diag_dom_ratio_local_d", local_rows_row);
-   PetscScalarKokkosView diag_dom_ratio_d = diag_dom_ratio_local_d;
+   // Create device memory for the diag_dom_ratio in the context
+   ctx->diag_dom_ratio_local_d = PetscScalarKokkosView("diag_dom_ratio_local_d", local_rows_row);
+   PetscScalarKokkosView diag_dom_ratio_d = ctx->diag_dom_ratio_local_d;
 
    // ~~~~~~~~~~~~~~~
    // Can now go and compute the diagonal dominance sums

--- a/src/PMISR_Module.F90
+++ b/src/PMISR_Module.F90
@@ -16,9 +16,13 @@ module pmisr_module
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
-   subroutine pmisr(strength_mat, max_luby_steps, pmis, cf_markers_local, zero_measure_c_point)
+   subroutine pmisr(strength_mat, max_luby_steps, pmis, cf_markers_local, cf_markers_handle, zero_measure_c_point)
 
       ! Wrapper
+      ! On the device the cf markers are left in the device context behind
+      ! cf_markers_handle (created here if it is c_null_ptr) rather than
+      ! copied back into cf_markers_local, and the caller is responsible
+      ! for destroying it with destroy_cf_markers_kokkos
 
       ! ~~~~~~
 
@@ -26,6 +30,7 @@ module pmisr_module
       integer, intent(in)                 :: max_luby_steps
       logical, intent(in)                 :: pmis
       integer, dimension(:), allocatable, target, intent(inout) :: cf_markers_local
+      type(c_ptr), intent(inout)          :: cf_markers_handle
       logical, optional, intent(in)       :: zero_measure_c_point
       integer :: errorcode
 
@@ -84,15 +89,16 @@ module pmisr_module
          allocate(cf_markers_local(local_rows))
          cf_markers_local_ptr = c_loc(cf_markers_local)
 
-         ! Creates a cf_markers on the device
-         call pmisr_kokkos(A_array, max_luby_steps, pmis_int, measure_local_ptr, zero_measure_c_point_int)
+         ! Creates a cf_markers on the device in the context behind cf_markers_handle
+         call pmisr_kokkos(cf_markers_handle, A_array, max_luby_steps, pmis_int, measure_local_ptr, &
+                  zero_measure_c_point_int)
 
          ! If debugging do a comparison between CPU and Kokkos results
          if (kokkos_debug()) then
 
             ! Kokkos PMISR by default now doesn't copy back to the host, as any following ddc calls
             ! use the device data
-            call copy_cf_markers_d2h(cf_markers_local_ptr)
+            call copy_cf_markers_d2h(cf_markers_handle, cf_markers_local_ptr)
             call pmisr_cpu(strength_mat, max_luby_steps, pmis, &
                            cf_markers_local_two, zero_measure_c_point)
 
@@ -108,6 +114,8 @@ module pmisr_module
                         cf_markers_local, zero_measure_c_point)
       end if
 #else
+      ! There are no device cf markers without Kokkos
+      cf_markers_handle = c_null_ptr
       call pmisr_cpu(strength_mat, max_luby_steps, pmis, &
                      cf_markers_local, zero_measure_c_point)
 #endif

--- a/src/PMISR_Modulek.kokkos.cxx
+++ b/src/PMISR_Modulek.kokkos.cxx
@@ -1307,10 +1307,17 @@ PETSC_INTERN void pmisr_existing_measure_implicit_transpose_kokkos(Mat *strength
 //------------------------------------------------------------------------------------------------------------------------
 
 // PMISR cf splitting but on the device
+// The resulting cf markers stay on the device in the CFMarkersKokkosCtx behind
+// handle (a pointer to a void*, ie a Fortran c_ptr by ref), which is created
+// here if handle is null and destroyed by destroy_cf_markers_kokkos
 // This no longer copies back to the host pointer cf_markers_local at the end
-// You have to explicitly call copy_cf_markers_d2h(cf_markers_local) to do this
-PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscReal *measure_local, const int zero_measure_c_point_int)
+// You have to explicitly call copy_cf_markers_d2h(handle, cf_markers_local) to do this
+PETSC_INTERN void pmisr_kokkos(void **handle, Mat *strength_mat, const int max_luby_steps, const int pmis_int, PetscReal *measure_local, const int zero_measure_c_point_int)
 {
+   PetscCheckAbort(handle, PETSC_COMM_SELF, PETSC_ERR_ARG_NULL, "Null pointer to the device cf markers handle");
+   // Create the device cf markers context if this is the first pmisr with this handle
+   if (!*handle) *handle = new CFMarkersKokkosCtx;
+   CFMarkersKokkosCtx *ctx = static_cast<CFMarkersKokkosCtx *>(*handle);
 
    MPI_Comm MPI_COMM_MATRIX;
    PetscInt local_rows, local_cols, global_rows, global_cols;
@@ -1344,11 +1351,11 @@ PETSC_INTERN void pmisr_kokkos(Mat *strength_mat, const int max_luby_steps, cons
    PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_local, &device_local_i, &device_local_j, NULL, &mtype));
    if (mpi) PetscCallVoid(MatSeqAIJGetCSRAndMemType(mat_nonlocal, &device_nonlocal_i, &device_nonlocal_j, NULL, &mtype));
 
-   // Device memory for the global variable cf_markers_local_d - be careful these aren't petsc ints
-   cf_markers_local_d = intKokkosView("cf_markers_local_d", local_rows);
-   // Can't use the global directly within the parallel
-   // regions on the device so just take a shallow copy
-   intKokkosView cf_markers_d = cf_markers_local_d;
+   // Device memory for the context's cf_markers_local_d - be careful these aren't petsc ints
+   ctx->cf_markers_local_d = intKokkosView("cf_markers_local_d", local_rows);
+   // Shallow copy of the context's view for use within the parallel
+   // regions on the device
+   intKokkosView cf_markers_d = ctx->cf_markers_local_d;
 
    // Host and device memory for the measure
    PetscScalarKokkosViewHost measure_local_h(measure_local, local_rows);


### PR DESCRIPTION
## Summary
- `cf_markers_local_d` and `diag_dom_ratio_local_d` in `src/Device_Datak.kokkos.cxx` were process-wide Kokkos views shared by `pmisr_kokkos`, `ddc_kokkos`, `MatDiagDomRatio_kokkos` and `create_cf_is_kokkos`, so two PCAIR instances setting up concurrently would collide on the same device storage. Same hazard the `VecISCopyLocalKokkosCtx` refactor fixed for the per-level IS views.
- Both views now live in a `CFMarkersKokkosCtx` (`include/kokkos_helper.hpp`), created by `pmisr_kokkos`, owned as an opaque `type(c_ptr)` local to `compute_cf_splitting`, threaded through `first_pass_splitting` / `pmisr` / `ddc` / `MatDiagDomRatio` into every kokkos entry point that used the globals, and freed by `destroy_cf_markers_kokkos` (replacing the two `delete_device_*` calls).
- Non-Kokkos builds assign the handle to null in the two producer routines, keeping the dummy argument used under gfortran `-Wall -Werror`.
- Convention note added to `docs/dev/kokkos.md`; CHANGELOG entry.

No new regression test: in a single-threaded MPI process two setups cannot interleave inside `compute_cf_splitting`, so the old collision is not deterministically reproducible from a driver. `tests/ex6_two_airg` still covers the refactored path.

## Test plan
- [x] `make -j3 build_tests` warning-free
- [x] `make check` + `make tests_short` (CPU)
- [x] same with `PETSC_OPTIONS="-mat_type aijkokkos -vec_type kokkos -dm_mat_type aijkokkos -dm_vec_type kokkos -on_error_abort"`
- [x] same with `PFLARE_KOKKOS_DEBUG=1` added
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)