### PR TITLE
Fix operator reference counting in the one level PCAIR paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ tests/ilu_factors_kokkos
 tests/mat_diag
 tests/matrandom
 tests/matrandom_check_reset
+tests/operator_refcount
 tests/pmisr_nonsymmetric
 tests/reuse_preconditioner
 tests/shell_block_apply

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ export TEST_TARGETS = ex12f \
 		  ex6_two_airg \
 		  ilu_factors \
 		  reuse_preconditioner \
+		  operator_refcount \
 		  pmisr_nonsymmetric
 # Include kokkos examples
 ifeq ($(PETSC_HAVE_KOKKOS),1)

--- a/src/AIR_Data_Type_Routines.F90
+++ b/src/AIR_Data_Type_Routines.F90
@@ -285,11 +285,6 @@ module air_data_type_routines
                   air_data%inv_coarsest_poly_data%coefficients => null()
                end if
             end if
-            ! If we're not doing full smoothing, we have built a matshell on the top grid
-            ! we use in the fc smoothing that needs to be destroyed
-            if (.NOT. air_data%options%full_smoothing_up_and_down) then
-               call reset_inverse_mat(air_data%coarse_matrix(1))
-            end if
          end if
       end if 
 

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -641,6 +641,10 @@ module air_mg_setup
             ! Input can be any matrix, we just need the correct type
             call MatGetVecType(air_data%A_fc(our_level), vec_type, ierr)
             call MatShellSetVecType(air_data%coarse_matrix(our_level), vec_type, ierr)
+
+            ! We now own the matrix on this level - on the top level this replaces
+            ! the input pmat, which we must never destroy
+            air_data%allocated_coarse_matrix(our_level) = .TRUE.
          end if         
 
          ! ~~~~~~~~~~~~
@@ -952,8 +956,12 @@ module air_mg_setup
       if (.NOT. (.NOT. PetscObjectIsNull(temp_mat) &
                   .AND. air_data%options%reuse_poly_coeffs)) then
 
-         ! We've already created our coarse solver if we've auto truncated         
-         if (.NOT. auto_truncated) then
+         ! We've already created our coarse solver if we've auto truncated
+         ! With only one level and no auto truncation we fall back to a jacobi PC
+         ! below and never call finish_approximate_inverse, so don't start one -
+         ! start_approximate_inverse takes a reference to the matrix that only
+         ! finish_approximate_inverse gives back
+         if (.NOT. auto_truncated .AND. no_levels > 1) then
             call timer_start(TIMER_ID_AIR_INVERSE)   
 
             call start_approximate_inverse(air_data%coarse_matrix(no_levels), &
@@ -1187,7 +1195,8 @@ module air_mg_setup
       else
          ! Precondition with the "coarse grid" solver we used to determine auto truncation
          if (auto_truncated) then
-            call PetscObjectReference(amat, ierr) 
+            ! PCSetOperators takes its own references to both matrices and drops
+            ! them in PCReset/PCDestroy, so don't take one here
             call PCSetOperators(pcmg_input, amat, &
                         air_data%inv_A_ff(no_levels), ierr)         
             call PCSetType(pcmg_input, PCMAT, ierr)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -300,6 +300,18 @@ run_tests_no_load_short_serial:
 	./reuse_preconditioner
 #
 	@echo ""
+	@echo "Test PCAIR gives back the operators it was given with their reference counts intact"
+	./operator_refcount -ksp_max_it 3
+	./operator_refcount -ksp_max_it 3 -pc_air_full_smoothing_up_and_down
+	@echo "Test operator reference counts with only one level - the jacobi fallback"
+	./operator_refcount -ksp_max_it 3 -pc_air_max_levels 1
+	./operator_refcount -ksp_max_it 3 -pc_air_max_levels 1 -pc_air_full_smoothing_up_and_down
+	@echo "Test operator reference counts with only one level - auto truncated with a tolerance that always truncates"
+	./operator_refcount -ksp_max_it 3 -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e10
+	./operator_refcount -ksp_max_it 3 -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e10 \
+	 -pc_air_full_smoothing_up_and_down
+#
+	@echo ""
 	@echo "Test AIRG with advection and fc smoothing"
 	./adv_diff_fd -da_grid_x 8 -da_grid_y 8 -pc_type air -ksp_max_it 3 -pc_air_smooth_type fc
 	@echo ""
@@ -874,6 +886,12 @@ else
 	@echo ""
 	@echo "Test PCAIR honours KSPSetReusePreconditioner when the pmat values change in place in parallel"
 	$(MPIEXEC) -n 2 ./reuse_preconditioner
+#
+	@echo ""
+	@echo "Test PCAIR gives back the operators it was given with their reference counts intact in parallel"
+	$(MPIEXEC) -n 2 ./operator_refcount -ksp_max_it 3
+	$(MPIEXEC) -n 2 ./operator_refcount -ksp_max_it 3 -pc_air_max_levels 1
+	$(MPIEXEC) -n 2 ./operator_refcount -ksp_max_it 3 -pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e10
 #
 	@echo ""
 	@echo "Test AIRG with advection and fc smoothing in parallel"

--- a/tests/operator_refcount.c
+++ b/tests/operator_refcount.c
@@ -1,0 +1,148 @@
+static char help[] = "Checks PCAIR returns the operators it was given with their reference counts intact.\n\n";
+
+/*
+  Builds a one-dimensional upwind advection operator, hands it to PCAIR as Amat
+  with a separate (duplicated) Pmat, and checks after the solver has been
+  destroyed that both matrices are still alive and hold exactly the one
+  reference this driver owns.
+
+  Any extra reference taken by PCAIR that is never given back leaks the caller's
+  matrix; any reference given back that PCAIR never took frees the caller's
+  matrix out from under it.  Both are caught here.
+*/
+
+#include <petscksp.h>
+#include "pflare.h"
+
+// Assemble the upwinded operator into mat, in the COO format so that assembly
+// happens on the device when needed
+static PetscErrorCode AssembleAdvection(Mat mat, PetscBool preallocate)
+{
+  PetscInt    i, local_size, global_row_start, global_row_end_plus_one, start_assign;
+  PetscInt    *oor, *ooc;
+  PetscScalar *v;
+  PetscCount  counter;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatGetLocalSize(mat, &local_size, NULL));
+  PetscCall(MatGetOwnershipRange(mat, &global_row_start, &global_row_end_plus_one));
+
+  PetscCall(PetscMalloc2(2 * local_size, &oor, 2 * local_size, &ooc));
+  PetscCall(PetscMalloc1(2 * local_size, &v));
+
+  counter = 0;
+  // Dirichlet condition on left boundary
+  if (global_row_start == 0) {
+    start_assign = 1;
+    oor[counter] = 0;
+    ooc[counter] = 0;
+    v[counter]   = 1.0;
+    counter      = counter + 1;
+  } else {
+    start_assign = global_row_start;
+  }
+
+  for (i = start_assign; i < global_row_end_plus_one; i++) {
+    // Upwinded dimensionless uniform grid finite difference operator
+    oor[counter] = i;
+    ooc[counter] = i - 1;
+    v[counter]   = -1.0;
+
+    oor[counter + 1] = i;
+    ooc[counter + 1] = i;
+    v[counter + 1]   = 1.0;
+
+    counter = counter + 2;
+  }
+
+  if (preallocate) PetscCall(MatSetPreallocationCOO(mat, counter, oor, ooc));
+  PetscCall(PetscFree2(oor, ooc));
+  PetscCall(MatSetValuesCOO(mat, v, INSERT_VALUES));
+  PetscCall(PetscFree(v));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+// Check the matrix is still alive and only this driver holds a reference to it
+static PetscErrorCode CheckOwnedAlone(Mat mat, PetscInt n, const char *name)
+{
+  PetscInt refct, global_rows;
+
+  PetscFunctionBeginUser;
+  // If the solver has already freed this out from under us then PETSc catches
+  // the dangling object here in a debug build
+  PetscCall(PetscObjectGetReference((PetscObject)mat, &refct));
+  PetscCheck(refct == 1, PetscObjectComm((PetscObject)mat), PETSC_ERR_LIB,
+             "%s has %" PetscInt_FMT " references after the solver was destroyed, expected 1", name, refct);
+  // Touch it to be sure it is still a usable matrix
+  PetscCall(MatGetSize(mat, &global_rows, NULL));
+  PetscCheck(global_rows == n, PetscObjectComm((PetscObject)mat), PETSC_ERR_LIB,
+             "%s has %" PetscInt_FMT " rows after the solver was destroyed, expected %" PetscInt_FMT, name, global_rows, n);
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+int main(int argc, char **args)
+{
+  Vec      x, b;
+  Mat      A, P;
+  KSP      ksp;
+  PC       pc;
+  // Small is fine - this checks reference counts, not convergence, but keep it
+  // big enough that the default options still build a hierarchy with several levels
+  PetscInt n = 50, local_size;
+
+  PetscFunctionBeginUser;
+  PetscCall(PetscInitialize(&argc, &args, (char *)0, help));
+
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));
+
+  // Register the pflare types
+  PCRegister_PFLARE();
+
+  PetscCall(VecCreate(PETSC_COMM_WORLD, &x));
+  PetscCall(VecSetSizes(x, PETSC_DECIDE, n));
+  PetscCall(VecSetFromOptions(x));
+  PetscCall(VecDuplicate(x, &b));
+  PetscCall(VecGetLocalSize(x, &local_size));
+  PetscCall(VecSet(b, 0.0));
+
+  PetscCall(MatCreate(PETSC_COMM_WORLD, &A));
+  PetscCall(MatSetSizes(A, local_size, local_size, n, n));
+  PetscCall(MatSetFromOptions(A));
+  PetscCall(AssembleAdvection(A, PETSC_TRUE));
+
+  // A separate preconditioner matrix - PCAIR must not confuse the two
+  PetscCall(MatCreate(PETSC_COMM_WORLD, &P));
+  PetscCall(MatSetSizes(P, local_size, local_size, n, n));
+  PetscCall(MatSetFromOptions(P));
+  PetscCall(AssembleAdvection(P, PETSC_TRUE));
+
+  PetscCall(KSPCreate(PETSC_COMM_WORLD, &ksp));
+  PetscCall(KSPSetInitialGuessNonzero(ksp, PETSC_TRUE));
+  PetscCall(KSPSetOperators(ksp, A, P));
+  PetscCall(KSPGetPC(ksp, &pc));
+  PetscCall(PCSetType(pc, PCAIR));
+  PetscCall(KSPSetFromOptions(ksp));
+
+  PetscCall(VecSet(x, 1.0));
+  PetscCall(KSPSolve(ksp, b, x));
+
+  // Change the values in place and solve again, so the setup that resets and
+  // rebuilds the hierarchy is checked as well as the first one
+  PetscCall(AssembleAdvection(A, PETSC_FALSE));
+  PetscCall(AssembleAdvection(P, PETSC_FALSE));
+  PetscCall(VecSet(x, 1.0));
+  PetscCall(KSPSolve(ksp, b, x));
+
+  PetscCall(VecDestroy(&x));
+  PetscCall(VecDestroy(&b));
+  PetscCall(KSPDestroy(&ksp));
+
+  PetscCall(CheckOwnedAlone(A, n, "Amat"));
+  PetscCall(CheckOwnedAlone(P, n, "Pmat"));
+
+  PetscCall(MatDestroy(&A));
+  PetscCall(MatDestroy(&P));
+
+  PetscCall(PetscFinalize());
+  return 0;
+}


### PR DESCRIPTION
## The bug

`PetscObjectReference(amat)` in the one-level auto-truncated branch of `setup_air_pcmg` has no matching destroy. Investigating it turned up **three** interlocking reference-count imbalances in the one-level paths, which cancel each other out whenever `Amat` and `Pmat` are the same matrix — which is every test we have, so none of them caught it.

1. **Extra reference on `amat`** (`AIR_MG_Setup.F90`) — `PCSetOperators` takes its own references to both matrices and drops them in `PCReset`/`PCDestroy` (it references first specifically so passing the same matrix is safe), so the manual reference is never given back.
2. **Over-destroy of the caller's `pmat`** (`AIR_Data_Type_Routines.F90`) — `reset_air_data` unconditionally destroyed `coarse_matrix(1)` whenever full smoothing was off, on the assumption that we had replaced it with our own MATSHELL. With one level the coarsening loop exits before that replacement happens, so it released a reference to the caller's `pmat` that we never took.
3. **Unreleased reference in the jacobi fallback** (`AIR_MG_Setup.F90`) — with one level and no auto truncation we fall back to a jacobi PC and never call `finish_approximate_inverse`, so the reference `start_approximate_inverse` takes is never given back (and the coefficient reductions are left dangling).

## Impact

With a separate `Pmat`, the auto-truncated one-level path leaks `Amat` **and** frees the caller's `Pmat` while they still hold it — PETSc aborts with `Object already free` on the next touch. With `-pc_air_full_smoothing_up_and_down` there is no compensating destroy at all, so the matrix simply leaks.

## The fix

- Drop the stray `PetscObjectReference`.
- Set `allocated_coarse_matrix(our_level)` when the level's MATSHELL is created, so the existing per-level teardown owns it, and remove the special-cased level-1 destroy. Level 1 is now only destroyed when we actually built the shell there.
- Only start the coarse-solver inverse when it will be finished (`no_levels > 1`).

## Test

New `tests/operator_refcount.c` hands PCAIR a distinct `Amat`/`Pmat`, solves, reassembles and solves again (covering the reset/rebuild path), then checks both matrices are still alive holding only the driver's own reference. Wired into `TEST_TARGETS` and the short serial/parallel groups over the multi-level, `-pc_air_max_levels 1` and forced-truncation configurations.

Against the pre-fix library it fails on exactly the three broken configurations:

```
-pc_air_max_levels 1 -pc_air_full_smoothing_up_and_down          Pmat has 3 references after the solver was destroyed, expected 1
-pc_air_auto_truncate_start_level 1 -pc_air_auto_truncate_tol 1e10   Object already free: Parameter # 1
  ... the same with -pc_air_full_smoothing_up_and_down            Amat has 3 references after the solver was destroyed, expected 1
```

and passes on all of them with the fix.

`make check` and `make tests_short` both pass, as do all 7 existing auto-truncation tests via `make tests_search TEST_MATCH="-pc_air_auto_truncate_start_level"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)