### PR TITLE
PCPFLAREINV: add PCApplyTranspose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tests/mat_diag
 tests/matrandom
 tests/matrandom_check_reset
 tests/operator_refcount
+tests/pflareinv_apply_transpose
 tests/pmisr_nonsymmetric
 tests/reuse_preconditioner
 tests/shell_block_apply

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ for earlier changes please see the git history.
 
 ## Unreleased
 
+- PCPFLAREINV now implements `PCApplyTranspose`, so it can be used as the
+  preconditioner in a `KSPSolveTranspose`. This works for every inverse type,
+  both assembled and matrix-free. It applies the exact transpose of what
+  `PCApply` applies rather than a separately computed approximate inverse of
+  `A^T`, so the two really are adjoints. The matrix-free polynomials do this by
+  applying the same polynomial to a virtual transpose of the operator, which is
+  valid as the coefficients are real, so `q(A)^T = q(A^T)`; that means the
+  operator itself has to support `MatMultTranspose`, which is checked with a
+  clear error for the case where the user has supplied their own MatShell as the
+  operator. `PCMatApplyTranspose` is not implemented directly, so it falls back
+  to PETSc applying `PCApplyTranspose` column by column
 - Fixed PCAIR not passing its options prefix down to its inner PCMG. The
   `-mg_coarse_*` / `-mg_levels_*` options were read unprefixed by every PCAIR
   in a program, and `-foo_mg_coarse_*` for a PCAIR with prefix `-foo_` was

--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ export TEST_TARGETS = ex12f \
 		  adv_1d \
 		  adv_1d_multi_rhs \
 		  shell_block_apply \
+		  pflareinv_apply_transpose \
 		  adv_diff_fd \
 		  ex6_cf_splitting \
 		  adv_diff_cg_supg \

--- a/src/AIR_MG_Setup.F90
+++ b/src/AIR_MG_Setup.F90
@@ -1061,7 +1061,8 @@ module air_mg_setup
                ! inv_A_ff, which is what PCMAT does with inv_A_ff as its Pmat
                ! We can't use PCMAT with a matrix-free inverse though, as its
                ! multiple rhs apply does a MatMatMult on the Pmat and the matshell
-               ! only has a MATOP_MULT - use a shell that does the same single rhs
+               ! only has MATOP_MULT and MATOP_MULT_TRANSPOSE - use a shell that
+               ! does the same single rhs
                ! arithmetic and knows how to do the block apply instead
                call MatGetType(air_data%inv_A_ff(our_level), mat_type_inv_aff, ierr)
                if (mat_type_inv_aff == MATSHELL) then

--- a/src/Approx_Inverse_Setup.F90
+++ b/src/Approx_Inverse_Setup.F90
@@ -11,7 +11,7 @@ module approx_inverse_setup
          start_gmres_polynomial_coefficients_power, &
          calculate_gmres_polynomial_coefficients_arnoldi, &
          build_gmres_polynomial_inverse
-   use gmres_poly_apply, only: petsc_matvec_da_poly_mf
+   use gmres_poly_apply, only: petsc_matvec_da_poly_mf, destroy_transpose_mat
    use gmres_poly_newton, only: &
          build_gmres_polynomial_newton_inverse, &
          calculate_gmres_polynomial_roots_newton
@@ -570,6 +570,10 @@ module approx_inverse_setup
                call VecDestroy(temp_vec, ierr)
                mat_ctx%mf_vec_diag_recip = temp_vec
             end if
+
+            ! Any transposed twin built by a transposed apply (MATOP_MULT_TRANSPOSE)
+            ! This is a no-op unless someone has actually done a PCApplyTranspose
+            call destroy_transpose_mat(mat_ctx, ierr)
 
             ! Neumann polynomial has extra context that needs deleting
             temp_mat = mat_ctx%mat_scaled

--- a/src/FC_Smooth_Block.F90
+++ b/src/FC_Smooth_Block.F90
@@ -349,9 +349,9 @@ module fc_smooth_block
 
       ! Applies one of our approximate inverses to a dense block of right hand
       ! sides, ie the multiple rhs version of MatMult(inv_mat, x, y)
-      ! The matrix-free polynomial inverses are matshells with only a MATOP_MULT,
-      ! so a product on them would fail - they go through the blockwise shell
-      ! apply instead
+      ! The matrix-free polynomial inverses are matshells with only a MATOP_MULT
+      ! and a MATOP_MULT_TRANSPOSE, so a product on them would fail - they go
+      ! through the blockwise shell apply instead
 
       ! ~~~~~~
       type(tMat), intent(in)        :: inv_mat

--- a/src/Gmres_Poly.F90
+++ b/src/Gmres_Poly.F90
@@ -11,7 +11,7 @@ module gmres_poly
          PFLARE_REAL_KIND
    use matshell_data_type, only: mat_ctxtype
    use gmres_poly_apply, only: petsc_matvec_poly_mf, petsc_matvec_right_scale_poly_mf, &
-         petsc_matvec_da_poly_mf
+         petsc_matvec_da_poly_mf, petsc_matvec_poly_transpose_mf
    use tsqr, only: finish_tsqr_parallel, start_tsqr, tsqr_buffers
    use gmres_poly_data_type, only: gmres_poly_data
    use petsc_helper, only: MatAXPYWrapper, destroy_matrix_reuse, &
@@ -1409,6 +1409,11 @@ end if
                call MatShellSetOperation(inv_matrix, &
                            MATOP_MULT, petsc_matvec_poly_mf, ierr)
             end if
+            ! The subroutine petsc_matvec_poly_transpose_mf applies the transpose of
+            ! whichever of the two above we just set - it builds a transposed twin of
+            ! this matshell on demand, see ensure_transpose_mat
+            call MatShellSetOperation(inv_matrix, &
+                        MATOP_MULT_TRANSPOSE, petsc_matvec_poly_transpose_mf, ierr)
 
             call MatAssemblyBegin(inv_matrix, MAT_FINAL_ASSEMBLY, ierr)
             call MatAssemblyEnd(inv_matrix, MAT_FINAL_ASSEMBLY, ierr) 

--- a/src/Gmres_Poly_Apply.F90
+++ b/src/Gmres_Poly_Apply.F90
@@ -55,6 +55,46 @@ module gmres_poly_apply
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
+   subroutine petsc_matvec_ida_neumann_poly_mf(mat, x, y)
+
+      ! Applies I-D^-1 A matrix-free
+      ! y = A x
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(tMat), intent(in)    :: mat
+      type(tVec) :: x
+      type(tVec) :: y
+
+      ! Local
+      PetscErrorCode :: ierr
+      type(mat_ctxtype), pointer :: mat_ctx_scaled => null()
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      call MatShellGetContext(mat, mat_ctx_scaled, ierr)
+
+      ! ~~~~~~~~~~~~
+      ! We want to apply (I-D^-1 A) x
+      ! ~~~~~~~~~~~~
+
+      ! Multiply by A
+      call MatMult(mat_ctx_scaled%mat, x, y, ierr)
+
+      ! Doing D^-1 on the result
+      call VecPointwiseDivide(y, y, mat_ctx_scaled%mf_temp_vec(MF_VEC_DIAG), ierr)
+
+      ! Now do x - D^-1 A x
+      call VecAXPBY(y, &
+               PFLARE_ONE, &
+               PFLARE_MINUS_ONE, &
+               x, ierr)
+
+   end subroutine petsc_matvec_ida_neumann_poly_mf
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
    subroutine petsc_matvec_poly_mf(mat, x, y)
 
       ! Applies a matrix polynomial matrix-free as an inverse
@@ -219,6 +259,262 @@ module gmres_poly_apply
       end do
 
    end subroutine petsc_horner
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine ensure_transpose_mat(mat_ctx, ierr)
+
+      ! Makes sure mat_ctx has a transposed twin, ie a matshell that applies the
+      ! transpose of whatever polynomial mat_ctx applies, and that the twin is
+      ! pointing at the current coefficients and diagonal
+      !
+      ! All our polynomials have real coefficients, so
+      !    q(A)^T = q(A^T)
+      ! and for the right diagonally scaled variants, using
+      !    D^-1 (A^T D^-1)^k = (D^-1 A^T)^k D^-1
+      ! we get
+      !    (q(D^-1 A) D^-1)^T = D^-1 q(A^T D^-1) = q(D^-1 A^T) D^-1
+      ! (and the same for the Neumann form with A replaced by I - D^-1 A, as
+      ! diag(A^T) = diag(A) so D is unchanged)
+      ! In other words the transpose has the identical shell structure with the
+      ! matrix replaced by its transpose, so the twin just runs the very same
+      ! forward callbacks against a MATTRANSPOSEVIRTUAL of mat_ctx%mat - none of
+      ! the horner/newton kernels need to know anything about transposes
+      !
+      ! Note the inner operator the scaled twin needs is D^-1 A^T, which is NOT
+      ! mat_scaled^T = A^T D^-1, so we cannot get there by putting a
+      ! MATOP_MULT_TRANSPOSE on the existing inner matshell - the twin builds its
+      ! own inner matshell around the transposed matrix instead
+      !
+      ! This is built lazily, so the very common case of never doing a transposed
+      ! apply costs nothing. Every rank reaches here through MatMultTranspose, so
+      ! the collective creation below is safe, in the same way the lazy
+      ! VecDuplicate in shell_poly_block_apply is
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(mat_ctxtype), intent(inout) :: mat_ctx
+      PetscErrorCode, intent(inout)    :: ierr
+
+      ! Local
+      logical :: scaled
+      PetscInt :: local_rows, local_cols, global_rows, global_cols
+      MPIU_Comm :: MPI_COMM_MATRIX
+      VecType :: vtype
+      type(tMat) :: temp_mat
+      type(mat_ctxtype), pointer :: twin => null(), twin_inner => null()
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Are we applying q(D^-1 A) D^-1 (or the Neumann equivalent) rather than q(A)?
+      temp_mat = mat_ctx%mat_scaled
+      scaled = .NOT. PetscObjectIsNull(temp_mat)
+
+      ! If the matrix has been swapped out from under us the twin is stale - the
+      ! MATTRANSPOSEVIRTUAL holds a reference to the old matrix, so it would
+      ! silently keep applying it
+      temp_mat = mat_ctx%transpose_mat
+      if (.NOT. PetscObjectIsNull(temp_mat)) then
+         if (mat_ctx%mf_transpose_source%v /= mat_ctx%mat%v) then
+            call destroy_transpose_mat(mat_ctx, ierr)
+         end if
+      end if
+
+      ! ~~~~~~~~~~~~
+      ! Build the twin if we don't have one
+      ! ~~~~~~~~~~~~
+      temp_mat = mat_ctx%transpose_mat
+      if (PetscObjectIsNull(temp_mat)) then
+
+         call PetscObjectGetComm(mat_ctx%mat, MPI_COMM_MATRIX, ierr)
+         call MatGetLocalSize(mat_ctx%mat, local_rows, local_cols, ierr)
+         call MatGetSize(mat_ctx%mat, global_rows, global_cols, ierr)
+         call MatGetVecType(mat_ctx%mat, vtype, ierr)
+
+         ! Have to dynamically allocate this
+         allocate(twin)
+
+         ! The transposed matrix - this is virtual, MatMult on it just calls
+         ! MatMultTranspose on mat_ctx%mat, so it costs no memory and no assembly
+         ! It takes a reference on mat_ctx%mat, dropped in destroy_transpose_mat
+         call MatCreateTranspose(mat_ctx%mat, twin%mat, ierr)
+
+         ! The twin shell itself - the row/col sizes are written swapped to say
+         ! what we mean, they are equal as our inverses are always square
+         call MatCreateShell(MPI_COMM_MATRIX, local_cols, local_rows, global_cols, global_rows, &
+                     twin, mat_ctx%transpose_mat, ierr)
+
+         ! Give the twin the same forward callback the original shell has - that is
+         ! what makes it apply the same polynomial, just to the transposed matrix
+         if (associated(mat_ctx%real_roots)) then
+            if (scaled) then
+               call MatShellSetOperation(mat_ctx%transpose_mat, &
+                           MATOP_MULT, petsc_matvec_right_scale_poly_newton_mf, ierr)
+            else
+               call MatShellSetOperation(mat_ctx%transpose_mat, &
+                           MATOP_MULT, petsc_matvec_poly_newton_mf, ierr)
+            end if
+         else
+            if (scaled) then
+               call MatShellSetOperation(mat_ctx%transpose_mat, &
+                           MATOP_MULT, petsc_matvec_right_scale_poly_mf, ierr)
+            else
+               call MatShellSetOperation(mat_ctx%transpose_mat, &
+                           MATOP_MULT, petsc_matvec_poly_mf, ierr)
+            end if
+         end if
+
+         call MatAssemblyBegin(mat_ctx%transpose_mat, MAT_FINAL_ASSEMBLY, ierr)
+         call MatAssemblyEnd(mat_ctx%transpose_mat, MAT_FINAL_ASSEMBLY, ierr)
+         ! Have to make sure to set the type of vectors the shell creates
+         call MatShellSetVecType(mat_ctx%transpose_mat, vtype, ierr)
+
+         ! The inner matshell, applying D^-1 A^T (or I - D^-1 A^T for the Neumann
+         ! polynomial) - the same callbacks the forward inner matshell uses, just
+         ! with the transposed matrix in the context
+         if (scaled) then
+
+            ! Have to dynamically allocate this
+            allocate(twin_inner)
+
+            call MatCreateShell(MPI_COMM_MATRIX, local_cols, local_rows, global_cols, global_rows, &
+                        twin_inner, twin%mat_scaled, ierr)
+            if (mat_ctx%neumann_inner) then
+               call MatShellSetOperation(twin%mat_scaled, &
+                           MATOP_MULT, petsc_matvec_ida_neumann_poly_mf, ierr)
+            else
+               call MatShellSetOperation(twin%mat_scaled, &
+                           MATOP_MULT, petsc_matvec_da_poly_mf, ierr)
+            end if
+
+            call MatAssemblyBegin(twin%mat_scaled, MAT_FINAL_ASSEMBLY, ierr)
+            call MatAssemblyEnd(twin%mat_scaled, MAT_FINAL_ASSEMBLY, ierr)
+            call MatShellSetVecType(twin%mat_scaled, vtype, ierr)
+
+            ! The inner shell borrows the transposed matrix, the twin owns it
+            twin_inner%mat = twin%mat
+         end if
+
+         ! Remember what we built the twin from, so we can spot it going stale
+         mat_ctx%mf_transpose_source = mat_ctx%mat
+      end if
+
+      ! ~~~~~~~~~~~~
+      ! Refresh everything the twin borrows, every single apply
+      ! This is not cosmetic - the builders deallocate and reallocate the
+      ! coefficients whenever the matshell is reused with the same nonzero pattern
+      ! but fresh coefficients are computed, and the diagonal in MF_VEC_DIAG is
+      ! updated in place, with no hook that would let us know either has happened
+      ! Everything here is borrowed from mat_ctx and must never be freed by the twin
+      ! ~~~~~~~~~~~~
+      call MatShellGetContext(mat_ctx%transpose_mat, twin, ierr)
+
+      twin%coefficients => mat_ctx%coefficients
+      twin%real_roots => mat_ctx%real_roots
+      twin%imag_roots => mat_ctx%imag_roots
+      ! The twin never owns the coefficients, mat_ctx does
+      twin%own_coefficients = .FALSE.
+      twin%neumann_inner = mat_ctx%neumann_inner
+      ! A forward and a transposed apply never overlap, so the twin can share the
+      ! scratch vectors rather than duplicating them. They are the right layout as
+      ! our inverses are always square
+      twin%mf_temp_vec = mat_ctx%mf_temp_vec
+
+      if (scaled) then
+         call MatShellGetContext(twin%mat_scaled, twin_inner, ierr)
+         twin_inner%coefficients => mat_ctx%coefficients
+         twin_inner%own_coefficients = .FALSE.
+         twin_inner%neumann_inner = mat_ctx%neumann_inner
+         ! diag(A^T) = diag(A), so the forward diagonal is exactly what the
+         ! transposed inner operator needs
+         twin_inner%mf_temp_vec(MF_VEC_DIAG) = mat_ctx%mf_temp_vec(MF_VEC_DIAG)
+      end if
+
+   end subroutine ensure_transpose_mat
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine destroy_transpose_mat(mat_ctx, ierr)
+
+      ! Destroys the transposed twin built by ensure_transpose_mat, if there is one
+      ! The twin borrows the coefficients, the roots, the diagonal and all the
+      ! scratch vectors from mat_ctx, so all we own here are the matrices
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(mat_ctxtype), intent(inout) :: mat_ctx
+      PetscErrorCode, intent(inout)    :: ierr
+
+      ! Local
+      type(tMat) :: temp_mat
+      type(mat_ctxtype), pointer :: twin => null(), twin_inner => null()
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      temp_mat = mat_ctx%transpose_mat
+      if (PetscObjectIsNull(temp_mat)) return
+
+      call MatShellGetContext(mat_ctx%transpose_mat, twin, ierr)
+
+      ! The inner matshell, if the twin has one - it borrows everything in its
+      ! context, so there is nothing but the shell to get rid of
+      temp_mat = twin%mat_scaled
+      if (.NOT. PetscObjectIsNull(temp_mat)) then
+         call MatShellGetContext(temp_mat, twin_inner, ierr)
+         deallocate(twin_inner)
+         call MatDestroy(temp_mat, ierr)
+         twin%mat_scaled = temp_mat
+      end if
+
+      ! The MATTRANSPOSEVIRTUAL, which drops the reference it holds on mat_ctx%mat
+      call MatDestroy(twin%mat, ierr)
+
+      deallocate(twin)
+
+      ! MatDestroy nulls the local copy of the handle, not the field in the
+      ! context, so copy the nulled handle back
+      temp_mat = mat_ctx%transpose_mat
+      call MatDestroy(temp_mat, ierr)
+      mat_ctx%transpose_mat = temp_mat
+      mat_ctx%mf_transpose_source = temp_mat
+
+   end subroutine destroy_transpose_mat
+
+! -------------------------------------------------------------------------------------------------------------------------------
+
+   subroutine petsc_matvec_poly_transpose_mf(mat, x, y)
+
+      ! Applies the transpose of a matrix-free polynomial inverse
+      ! This is the MATOP_MULT_TRANSPOSE of every polynomial matshell we build -
+      ! one routine covers all of them, because the twin built by
+      ! ensure_transpose_mat already carries the right forward arithmetic
+      ! y = A^T x
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      ! Input
+      type(tMat), intent(in)    :: mat
+      type(tVec) :: x
+      type(tVec) :: y
+
+      ! Local
+      PetscErrorCode :: ierr
+      type(mat_ctxtype), pointer :: mat_ctx => null()
+
+      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      call MatShellGetContext(mat, mat_ctx, ierr)
+
+      ! Build the transposed twin the first time round
+      call ensure_transpose_mat(mat_ctx, ierr)
+
+      ! The twin applies the same polynomial to the transposed matrix, which is
+      ! exactly the transpose of what mat applies
+      call MatMult(mat_ctx%transpose_mat, x, y, ierr)
+
+   end subroutine petsc_matvec_poly_transpose_mf
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/Gmres_Poly_Newton.F90
+++ b/src/Gmres_Poly_Newton.F90
@@ -8,7 +8,8 @@ module gmres_poly_newton
          PFLARE_ONE, PFLARE_ZERO, PFLARE_MINUS_ONE, PFLARE_TWO, PFLARE_MATMULT_FILL, &
          PFLARE_TOL_MATFREE_NEWTON, PFLARE_TOL_LEJA_PERTURB
    use gmres_poly_apply, only: petsc_matvec_poly_newton_mf, &
-         petsc_matvec_right_scale_poly_newton_mf, petsc_matvec_da_poly_mf
+         petsc_matvec_right_scale_poly_newton_mf, petsc_matvec_da_poly_mf, &
+         petsc_matvec_poly_transpose_mf
 
 #include "petsc/finclude/petscmat.h"
 #include "finclude/pflare_blaslapack.h"
@@ -1560,6 +1561,11 @@ end if
             call MatShellSetOperation(inv_matrix, &
                         MATOP_MULT, petsc_matvec_poly_newton_mf, ierr)
             end if
+            ! The subroutine petsc_matvec_poly_transpose_mf applies the transpose of
+            ! whichever of the two above we just set - it builds a transposed twin of
+            ! this matshell on demand, see ensure_transpose_mat
+            call MatShellSetOperation(inv_matrix, &
+                        MATOP_MULT_TRANSPOSE, petsc_matvec_poly_transpose_mf, ierr)
 
             call MatAssemblyBegin(inv_matrix, MAT_FINAL_ASSEMBLY, ierr)
             call MatAssemblyEnd(inv_matrix, MAT_FINAL_ASSEMBLY, ierr)

--- a/src/Matshell_Data_Type.F90
+++ b/src/Matshell_Data_Type.F90
@@ -43,6 +43,15 @@ module matshell_data_type
       ! The reciprocal of mf_temp_vec(MF_VEC_DIAG), only used by the block applies
       ! of the diagonally scaled polynomials
       type(tVec) :: mf_vec_diag_recip
+      ! The transposed twin of this polynomial, built lazily the first time a
+      ! transposed apply happens (MATOP_MULT_TRANSPOSE) - see ensure_transpose_mat
+      ! It is a matshell running the very same forward arithmetic as this one, but
+      ! against a MATTRANSPOSEVIRTUAL of mat, which is all the transpose needs as
+      ! our polynomials have real coefficients, so q(A)^T = q(A^T)
+      type(tMat) :: transpose_mat
+      ! The mat the twin above was built from, so we can spot mat being swapped
+      ! out from under us - the same handle comparison as mf_product_mat
+      type(tMat) :: mf_transpose_source
       type(air_multigrid_data), pointer :: air_data => null()
 
    end type mat_ctxtype

--- a/src/Neumann_Poly.F90
+++ b/src/Neumann_Poly.F90
@@ -2,7 +2,8 @@ module neumann_poly
 
    use petscmat
    use gmres_poly, only: build_gmres_polynomial_inverse
-   use gmres_poly_apply, only: petsc_matvec_right_scale_poly_mf
+   use gmres_poly_apply, only: petsc_matvec_right_scale_poly_mf, &
+         petsc_matvec_ida_neumann_poly_mf, petsc_matvec_poly_transpose_mf
    use matshell_data_type, only: mat_ctxtype
    use tsqr, only: tsqr_buffers
    use pflare_parameters, only: PFLAREINV_NEUMANN, MF_VEC_DIAG, MF_VEC_RHS, MF_VEC_TEMP, &
@@ -14,46 +15,6 @@ module neumann_poly
    public
    
    contains
-
-! -------------------------------------------------------------------------------------------------------------------------------
-
-   subroutine petsc_matvec_ida_neumann_poly_mf(mat, x, y)
-
-      ! Applies I-D^-1 A matrix-free
-      ! y = A x
-
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      ! Input
-      type(tMat), intent(in)    :: mat
-      type(tVec) :: x
-      type(tVec) :: y
-
-      ! Local
-      PetscErrorCode :: ierr
-      type(mat_ctxtype), pointer :: mat_ctx_scaled => null()
-
-      ! ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      call MatShellGetContext(mat, mat_ctx_scaled, ierr)
-
-      ! ~~~~~~~~~~~~
-      ! We want to apply (I-D^-1 A) x
-      ! ~~~~~~~~~~~~
-
-      ! Multiply by A
-      call MatMult(mat_ctx_scaled%mat, x, y, ierr)
-
-      ! Doing D^-1 on the result
-      call VecPointwiseDivide(y, y, mat_ctx_scaled%mf_temp_vec(MF_VEC_DIAG), ierr)
-
-      ! Now do x - D^-1 A x
-      call VecAXPBY(y, &
-               PFLARE_ONE, &
-               PFLARE_MINUS_ONE, &
-               x, ierr)
-
-   end subroutine petsc_matvec_ida_neumann_poly_mf
 
 ! -------------------------------------------------------------------------------------------------------------------------------
 
@@ -123,6 +84,11 @@ module neumann_poly
             ! q(mat) D^-1
             call MatShellSetOperation(inv_matrix, &
                         MATOP_MULT, petsc_matvec_right_scale_poly_mf, ierr)
+            ! The subroutine petsc_matvec_poly_transpose_mf applies the transpose of
+            ! the above - it builds a transposed twin of this matshell on demand,
+            ! see ensure_transpose_mat
+            call MatShellSetOperation(inv_matrix, &
+                        MATOP_MULT_TRANSPOSE, petsc_matvec_poly_transpose_mf, ierr)
 
             call MatAssemblyBegin(inv_matrix, MAT_FINAL_ASSEMBLY, ierr)
             call MatAssemblyEnd(inv_matrix, MAT_FINAL_ASSEMBLY, ierr)

--- a/src/PCPFLAREINV.c
+++ b/src/PCPFLAREINV.c
@@ -662,6 +662,41 @@ static PetscErrorCode PCApply_PFLAREINV_c(PC pc, Vec x, Vec y)
 
 // ~~~~~~~~~~
 
+// Transposed apply, y = mat_inverse^T x - this is the exact transpose of PCApply,
+// not a separately computed approximate inverse of A^T (which would be a different
+// polynomial and hence not an adjoint of what PCApply does).
+// The assembled inverses transpose natively (aij, and matdiagonal for the jacobi
+// types and for poly_order 0). The matrix-free polynomials register a
+// MATOP_MULT_TRANSPOSE that applies the same polynomial to a virtual transpose of
+// the operator, which works because our coefficients are real, so q(A)^T = q(A^T).
+static PetscErrorCode PCApplyTranspose_PFLAREINV_c(PC pc, Vec x, Vec y)
+{
+   PC_PFLAREINV *inv_data;
+   PetscFunctionBegin;
+   inv_data = (PC_PFLAREINV *)pc->data;
+
+   // A matrix-free inverse applies the operator itself, so the operator has to
+   // know how to do a transposed matvec. That is always true of the assembled
+   // types PFLARE builds, but the user is free to hand us their own MatShell as
+   // the operator (which is why we never turn on the diagonal scaling below), and
+   // theirs may only have MATOP_MULT. Catch that here rather than letting it fail
+   // several layers down with an error that mentions neither PFLARE nor which of
+   // the shells in play is the problem.
+   if (inv_data->matrix_free) {
+      PetscBool has_transpose;
+      PetscCall(MatHasOperation(pc->pmat, MATOP_MULT_TRANSPOSE, &has_transpose));
+      PetscCheck(has_transpose, PetscObjectComm((PetscObject)pc), PETSC_ERR_SUP, \
+            "PCPFLAREINV cannot apply its transpose matrix-free as the operator has no MatMultTranspose - " \
+            "register MATOP_MULT_TRANSPOSE on your MatShell, or don't use -pc_pflareinv_matrix_free");
+   }
+
+   // Just call a transposed matmult
+   PetscCall(MatMultTranspose(inv_data->mat_inverse, x, y));
+   PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+// ~~~~~~~~~~
+
 // Multi-RHS apply: Y = mat_inverse * X for dense X, Y.
 // Lets KSPMatSolve / PCMatApply hit a real SpMM (cuSPARSE/hipSPARSE/Kokkos/CPU
 // AIJxDense) instead of PETSc's default column-by-column PCApply fallback.
@@ -672,7 +707,8 @@ static PetscErrorCode PCMatApply_PFLAREINV_c(PC pc, Mat X, Mat Y)
    inv_data = (PC_PFLAREINV *)pc->data;
 
    if (inv_data->matrix_free) {
-      // mat_inverse is a MatShell with only MATOP_MULT registered, so MatMatMult on it
+      // mat_inverse is a MatShell with only MATOP_MULT and MATOP_MULT_TRANSPOSE
+      // registered, so MatMatMult on it
       // would fail. The polynomial matshells can however be applied blockwise by
       // doing the products with the underlying matrix - the Fortran routine below does
       // that and reports whether it managed it.
@@ -1074,6 +1110,9 @@ PETSC_EXTERN PetscErrorCode PCCreate_PFLAREINV(PC pc)
    // Set the method functions
    pc->ops->apply               = PCApply_PFLAREINV_c;
    pc->ops->matapply            = PCMatApply_PFLAREINV_c;
+   // We deliberately don't set matapplytranspose - PCMatApplyTranspose falls back to
+   // applying PCApplyTranspose column by column when it is NULL, which is correct
+   pc->ops->applytranspose      = PCApplyTranspose_PFLAREINV_c;
    pc->ops->setup               = PCSetUp_PFLAREINV_c;
    pc->ops->destroy             = PCDestroy_PFLAREINV_c;
    pc->ops->view                = PCView_PFLAREINV_c;  

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -666,6 +666,42 @@ run_tests_no_load_short_serial:
 	./shell_block_apply -n 1000 -nrhs 5 -inverse_type 4
 #
 	@echo ""
+	@echo "Test PCApplyTranspose with an assembled PCPFLAREINV"
+	$(SKIP_SINGLE) ./pflareinv_apply_transpose
+	@echo "Test PCApplyTranspose with an assembled Arnoldi PCPFLAREINV"
+	./pflareinv_apply_transpose -pc_pflareinv_type arnoldi
+	@echo "Test PCApplyTranspose with an assembled Newton PCPFLAREINV"
+	./pflareinv_apply_transpose -pc_pflareinv_type newton
+	@echo "Test PCApplyTranspose with an assembled Neumann PCPFLAREINV"
+	./pflareinv_apply_transpose -pc_pflareinv_type neumann
+	@echo "Test PCApplyTranspose with the assembled non-polynomial PCPFLAREINVs"
+	./pflareinv_apply_transpose -pc_pflareinv_type sai
+	./pflareinv_apply_transpose -pc_pflareinv_type isai
+	./pflareinv_apply_transpose -pc_pflareinv_type wjacobi
+	./pflareinv_apply_transpose -pc_pflareinv_type jacobi
+	@echo "Test PCApplyTranspose with a matrix-free PCPFLAREINV - builds the transposed matshell twin"
+	$(SKIP_SINGLE) ./pflareinv_apply_transpose -pc_pflareinv_matrix_free
+	@echo "Test PCApplyTranspose with a matrix-free Arnoldi PCPFLAREINV"
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type arnoldi
+	@echo "Test PCApplyTranspose with a matrix-free Newton PCPFLAREINV"
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton
+	@echo "Test PCApplyTranspose with a matrix-free Newton no extra PCPFLAREINV"
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton_no_extra \
+	 -pc_pflareinv_poly_order 10
+	@echo "Test PCApplyTranspose with a matrix-free Neumann PCPFLAREINV - the right diagonally scaled path"
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type neumann
+	@echo "Test PCApplyTranspose after the operator values change - the twin has to pick up new coefficients"
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton -rebuild
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type neumann -rebuild
+	./pflareinv_apply_transpose -pc_pflareinv_type newton -rebuild
+	@echo "Test KSPSolveTranspose through PCPFLAREINV, assembled and matrix-free"
+	./pflareinv_apply_transpose -pc_pflareinv_type newton -transpose_solve -ksp_max_it 100
+	./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton \
+	 -transpose_solve -ksp_max_it 100
+	@echo "Test PCApplyTranspose at a size too big for the explicit check"
+	./pflareinv_apply_transpose -n 5000 -pc_pflareinv_matrix_free -pc_pflareinv_type newton
+#
+	@echo ""
 	@echo "Test 3D upwind finite-difference"
 	./adv_diff_fd -dim 3 -da_grid_x 10 -da_grid_y 10 -da_grid_z 10 -pc_type air -ksp_pc_side right \
 	 -ksp_rtol $(KSP_RTOL) -ksp_atol 1e-50 -pc_air_a_lump -ksp_max_it 4
@@ -1167,6 +1203,25 @@ else
 	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 2
 	@echo "Test the block apply of the matrix-free Neumann matshell directly in parallel"
 	$(MPIEXEC) -n 2 ./shell_block_apply -n 1000 -nrhs 5 -inverse_type 4
+#	
+	@echo ""
+	@echo "Test PCApplyTranspose with an assembled PCPFLAREINV in parallel"
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_type arnoldi
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_type newton
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_type neumann
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_type wjacobi
+	@echo "Test PCApplyTranspose with a matrix-free PCPFLAREINV in parallel - builds the transposed matshell twin"
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type arnoldi
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton
+	@echo "Test PCApplyTranspose with a matrix-free Neumann PCPFLAREINV in parallel - the right diagonally scaled path"
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type neumann
+	@echo "Test PCApplyTranspose after the operator values change in parallel"
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton -rebuild
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type neumann -rebuild
+	@echo "Test KSPSolveTranspose through PCPFLAREINV in parallel, assembled and matrix-free"
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_type newton -transpose_solve -ksp_max_it 100
+	$(MPIEXEC) -n 2 ./pflareinv_apply_transpose -pc_pflareinv_matrix_free -pc_pflareinv_type newton \
+	 -transpose_solve -ksp_max_it 100
 #
 	@echo ""
 	@echo "Test 3D upwind finite-difference in parallel"

--- a/tests/pflareinv_apply_transpose.c
+++ b/tests/pflareinv_apply_transpose.c
@@ -1,0 +1,395 @@
+static char help[] = "Tests PCApplyTranspose for PCPFLAREINV.\n\n";
+
+/*
+  Checks that PCApplyTranspose on PCPFLAREINV really is the transpose of PCApply,
+  for every inverse type, both assembled and matrix-free.
+
+  There are two checks, both comparing the preconditioner against itself, so
+  neither needs a reference implementation - which matters for the matrix-free
+  polynomials, where the assembled and matrix-free applies are not bit-identical
+  operators:
+
+  - the bilinear identity  y . (M x) == x . (M^T y)  over random vectors, which
+    is cheap enough to run at any size
+  - building M and M^T out column by column and comparing every entry, which is
+    2n applies so it is only run on a small operator, but is far sharper. The
+    bilinear identity contracts a whole matrix down to one number and so is only
+    mildly sensitive; the explicit check catches a transposed apply that is
+    subtly rather than grossly wrong.
+
+  The operator has to be strongly nonsymmetric or this test proves nothing at
+  all - a symmetric one would pass no matter what the transposed apply did. We
+  use a 1D upwind advection-diffusion stencil with a shift that makes it
+  strictly diagonally dominant, so it is cheap, nonsingular, and the Neumann
+  polynomial converges on it.
+
+    ./pflareinv_apply_transpose
+    ./pflareinv_apply_transpose -pc_pflareinv_type neumann -pc_pflareinv_matrix_free
+    mpiexec -n 2 ./pflareinv_apply_transpose -pc_pflareinv_type newton
+    ./pflareinv_apply_transpose -transpose_solve
+
+  The explicit check is skipped above -explicit_max rows, so -n 5000 is a
+  bilinear-identity-only run at a realistic size.
+
+  -rebuild re-does the setup with new values in the same nonzero pattern and
+  re-checks, which is what covers the transposed twin being refreshed rather
+  than left pointing at stale coefficients.
+*/
+#include <petscksp.h>
+#include "pflare.h"
+
+// Tolerance for the transpose identity
+#if defined(PETSC_USE_REAL_SINGLE)
+  #define DEFAULT_CHECK_TOL 1e-5
+#else
+  #define DEFAULT_CHECK_TOL 1e-10
+#endif
+
+/*
+   Writes the 1D upwind advection-diffusion stencil into A. The advection makes
+   the sub and super diagonals differ, ie A != A^T, and the shift keeps it
+   strictly diagonally dominant. Called again with a different advection to test
+   a re-setup with the same nonzero pattern.
+*/
+static PetscErrorCode SetOperatorValues(Mat A, PetscInt n, PetscReal advection, PetscReal shift)
+{
+  PetscInt    i, global_row_start, global_row_end_plus_one, cols[3], n_cols;
+  PetscScalar vals[3];
+
+  PetscFunctionBeginUser;
+  PetscCall(MatGetOwnershipRange(A, &global_row_start, &global_row_end_plus_one));
+
+  for (i = global_row_start; i < global_row_end_plus_one; i++) {
+    n_cols = 0;
+    if (i > 0) {
+      cols[n_cols] = i - 1;
+      vals[n_cols] = -1.0 - advection;
+      n_cols++;
+    }
+    cols[n_cols] = i;
+    vals[n_cols] = 2.0 + advection + shift;
+    n_cols++;
+    if (i < n - 1) {
+      cols[n_cols] = i + 1;
+      vals[n_cols] = -1.0;
+      n_cols++;
+    }
+    PetscCall(MatSetValues(A, 1, &i, n_cols, cols, vals, INSERT_VALUES));
+  }
+
+  PetscCall(MatAssemblyBegin(A, MAT_FINAL_ASSEMBLY));
+  PetscCall(MatAssemblyEnd(A, MAT_FINAL_ASSEMBLY));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+static PetscErrorCode BuildOperator(PetscInt n, PetscReal advection, PetscReal shift, Mat *A_out)
+{
+  Mat A;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatCreate(PETSC_COMM_WORLD, &A));
+  PetscCall(MatSetSizes(A, PETSC_DECIDE, PETSC_DECIDE, n, n));
+  PetscCall(MatSetFromOptions(A));
+  // Three per row on the diagonal block, at most one either side off it
+  PetscCall(MatSeqAIJSetPreallocation(A, 3, NULL));
+  PetscCall(MatMPIAIJSetPreallocation(A, 3, NULL, 2, NULL));
+  PetscCall(MatSetUp(A));
+
+  PetscCall(SetOperatorValues(A, n, advection, shift));
+
+  *A_out = A;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   The transpose identity itself. Uses VecTDot rather than VecDot so this is the
+   bilinear form in both real and complex builds - PCApplyTranspose is the true
+   transpose, not the Hermitian transpose.
+*/
+static PetscErrorCode CheckTransposeIdentity(PC pc, Mat A, PetscRandom rand, PetscReal tol, \
+                                             PetscInt n_pairs, const char *label)
+{
+  Vec         x, y, mx, mty;
+  PetscScalar lhs, rhs;
+  PetscReal   diff, denom;
+  PetscInt    i;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatCreateVecs(A, &x, &mx));
+  PetscCall(MatCreateVecs(A, &y, &mty));
+
+  for (i = 0; i < n_pairs; i++) {
+    // Random vectors - constant ones would hide a row/column mixup
+    PetscCall(VecSetRandom(x, rand));
+    PetscCall(VecSetRandom(y, rand));
+
+    PetscCall(PCApply(pc, x, mx));
+    PetscCall(PCApplyTranspose(pc, y, mty));
+
+    // y . (M x) has to equal x . (M^T y)
+    PetscCall(VecTDot(mx, y, &lhs));
+    PetscCall(VecTDot(x, mty, &rhs));
+
+    diff  = PetscAbsScalar(lhs - rhs);
+    denom = PetscMax(PetscAbsScalar(lhs), PetscAbsScalar(rhs));
+    if (denom < 1.0) denom = 1.0;
+
+    PetscCheck(diff / denom <= tol, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+               "%s: PCApplyTranspose is not the transpose of PCApply on pair %" PetscInt_FMT \
+               " - y.(Mx) = %g, x.(M^T y) = %g, relative difference %g > %g", \
+               label, i, (double)PetscRealPart(lhs), (double)PetscRealPart(rhs), \
+               (double)(diff / denom), (double)tol);
+  }
+
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, "  %s: transpose identity holds over %" PetscInt_FMT " vector pairs\n", \
+                        label, n_pairs));
+
+  PetscCall(VecDestroy(&x));
+  PetscCall(VecDestroy(&y));
+  PetscCall(VecDestroy(&mx));
+  PetscCall(VecDestroy(&mty));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   Builds the preconditioner out explicitly, one column at a time, either as M or
+   as M^T.
+*/
+static PetscErrorCode BuildExplicit(PC pc, Mat A, PetscInt n, PetscBool transpose, Mat *out)
+{
+  Mat      dense;
+  Vec      e, col;
+  VecType  vtype;
+  PetscInt j, local_rows;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatGetLocalSize(A, &local_rows, NULL));
+  // From the operator's vector type, so the columns we hand to PCApply are the
+  // same type as the vectors the preconditioner works with on the device
+  PetscCall(MatGetVecType(A, &vtype));
+  PetscCall(MatCreateDenseFromVecType(PetscObjectComm((PetscObject)A), vtype, local_rows, PETSC_DECIDE, \
+                                      n, n, PETSC_DECIDE, NULL, &dense));
+  PetscCall(MatCreateVecs(A, NULL, &e));
+
+  for (j = 0; j < n; j++) {
+    PetscCall(VecZeroEntries(e));
+    PetscCall(VecSetValue(e, j, 1.0, INSERT_VALUES));
+    PetscCall(VecAssemblyBegin(e));
+    PetscCall(VecAssemblyEnd(e));
+
+    PetscCall(MatDenseGetColumnVecWrite(dense, j, &col));
+    if (transpose) {
+      PetscCall(PCApplyTranspose(pc, e, col));
+    } else {
+      PetscCall(PCApply(pc, e, col));
+    }
+    PetscCall(MatDenseRestoreColumnVecWrite(dense, j, &col));
+  }
+
+  PetscCall(MatAssemblyBegin(dense, MAT_FINAL_ASSEMBLY));
+  PetscCall(MatAssemblyEnd(dense, MAT_FINAL_ASSEMBLY));
+  PetscCall(VecDestroy(&e));
+
+  *out = dense;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   The sharp version of the check - build M and M^T out column by column and
+   compare every single entry, rather than the single number the bilinear
+   identity gives us. Only worth doing on a small operator, but it is what
+   catches a transposed apply that is subtly rather than grossly wrong, for
+   instance one that applied the diagonal scaling on the wrong side.
+*/
+static PetscErrorCode CheckTransposeExplicitly(PC pc, Mat A, PetscInt n, PetscReal tol, const char *label)
+{
+  Mat       m, mt, mt_transposed;
+  PetscReal diff, scale;
+
+  PetscFunctionBeginUser;
+  PetscCall(BuildExplicit(pc, A, n, PETSC_FALSE, &m));
+  PetscCall(BuildExplicit(pc, A, n, PETSC_TRUE, &mt));
+
+  // (M^T)^T has to be M, entry for entry
+  PetscCall(MatTranspose(mt, MAT_INITIAL_MATRIX, &mt_transposed));
+  PetscCall(MatNorm(m, NORM_FROBENIUS, &scale));
+  PetscCall(MatAXPY(mt_transposed, -1.0, m, SAME_NONZERO_PATTERN));
+  PetscCall(MatNorm(mt_transposed, NORM_FROBENIUS, &diff));
+
+  if (scale < 1.0) scale = 1.0;
+  PetscCheck(diff / scale <= tol, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+             "%s: the explicit PCApplyTranspose matrix is not the transpose of the explicit PCApply matrix" \
+             " - relative Frobenius difference %g > %g", label, (double)(diff / scale), (double)tol);
+
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, \
+                        "  %s: explicit %" PetscInt_FMT "x%" PetscInt_FMT \
+                        " transpose matches entry for entry, relative difference %g\n", \
+                        label, n, n, (double)(diff / scale)));
+
+  PetscCall(MatDestroy(&m));
+  PetscCall(MatDestroy(&mt));
+  PetscCall(MatDestroy(&mt_transposed));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   Runs one solve and reports the iteration count, checking both that the KSP
+   converged and that the answer really does solve the system it claimed to.
+*/
+static PetscErrorCode RunSolve(Mat A, PCSide side, PetscBool transpose, PetscInt *its_out)
+{
+  KSP                ksp;
+  PC                 pc;
+  Vec                b, x, r;
+  PetscReal          rnorm, bnorm;
+  KSPConvergedReason reason;
+
+  PetscFunctionBeginUser;
+  PetscCall(MatCreateVecs(A, &x, &b));
+  PetscCall(VecDuplicate(b, &r));
+  PetscCall(VecSet(b, 1.0));
+
+  PetscCall(KSPCreate(PETSC_COMM_WORLD, &ksp));
+  PetscCall(KSPSetOperators(ksp, A, A));
+  PetscCall(KSPGetPC(ksp, &pc));
+  PetscCall(PCSetType(pc, PCPFLAREINV));
+  PetscCall(KSPSetFromOptions(ksp));
+  // After KSPSetFromOptions so this wins over -ksp_pc_side, we are deliberately
+  // comparing the two sides here
+  PetscCall(KSPSetPCSide(ksp, side));
+
+  if (transpose) {
+    PetscCall(KSPSolveTranspose(ksp, b, x));
+  } else {
+    PetscCall(KSPSolve(ksp, b, x));
+  }
+
+  PetscCall(KSPGetConvergedReason(ksp, &reason));
+  PetscCheck(reason > 0, PETSC_COMM_WORLD, PETSC_ERR_NOT_CONVERGED, \
+             "%s did not converge, reason %s", transpose ? "KSPSolveTranspose" : "KSPSolve", \
+             KSPConvergedReasons[reason]);
+
+  // The true residual of the system we actually asked for
+  if (transpose) {
+    PetscCall(MatMultTranspose(A, x, r));
+  } else {
+    PetscCall(MatMult(A, x, r));
+  }
+  PetscCall(VecAXPY(r, -1.0, b));
+  PetscCall(VecNorm(r, NORM_2, &rnorm));
+  PetscCall(VecNorm(b, NORM_2, &bnorm));
+
+  PetscCheck(rnorm / bnorm <= 1e-4, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+             "%s converged but the answer does not solve the system, relative residual %g", \
+             transpose ? "KSPSolveTranspose" : "KSPSolve", (double)(rnorm / bnorm));
+
+  PetscCall(KSPGetIterationNumber(ksp, its_out));
+
+  PetscCall(KSPDestroy(&ksp));
+  PetscCall(VecDestroy(&x));
+  PetscCall(VecDestroy(&b));
+  PetscCall(VecDestroy(&r));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/*
+   End to end check - does the transposed apply actually precondition as well as
+   the forward one does?
+
+   With M the approximate inverse, left preconditioned GMRES on the transposed
+   system iterates on M^T A^T = (A M)^T, which has the spectrum of A M, ie of the
+   RIGHT preconditioned forward problem rather than the left preconditioned M A.
+   So the forward count to compare against in general is the right preconditioned
+   one, and that is what this asserts against. Both forward counts are reported,
+   and on an operator as well behaved as this one they come out the same anyway,
+   so this does not actually distinguish the two - it is the theoretically
+   correct reference, not a demonstrated distinction.
+
+   A transposed apply that was subtly wrong would still often converge, just more
+   slowly, so this catches things the algebraic checks above would not.
+*/
+static PetscErrorCode CheckTransposeSolve(Mat A, PetscInt its_slack)
+{
+  PetscInt its_left, its_right, its_transpose, gap;
+
+  PetscFunctionBeginUser;
+  PetscCall(RunSolve(A, PC_LEFT, PETSC_FALSE, &its_left));
+  PetscCall(RunSolve(A, PC_RIGHT, PETSC_FALSE, &its_right));
+  PetscCall(RunSolve(A, PC_LEFT, PETSC_TRUE, &its_transpose));
+
+  gap = PetscAbsInt(its_transpose - its_right);
+  PetscCheck(gap <= its_slack, PETSC_COMM_WORLD, PETSC_ERR_PLIB, \
+             "the transposed solve does not converge like the forward one - transposed took %" PetscInt_FMT \
+             " iterations against %" PetscInt_FMT " for the equivalent forward right preconditioned solve," \
+             " a gap of %" PetscInt_FMT " > %" PetscInt_FMT, its_transpose, its_right, gap, its_slack);
+
+  PetscCall(PetscPrintf(PETSC_COMM_WORLD, \
+                        "  solves converged in %" PetscInt_FMT " its transposed, against %" PetscInt_FMT \
+                        " forward right preconditioned and %" PetscInt_FMT \
+                        " forward left preconditioned\n", its_transpose, its_right, its_left));
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+int main(int argc, char **args)
+{
+  Mat         A;
+  PC          pc;
+  PetscRandom rand;
+  PetscInt    n = 200, n_pairs = 5, explicit_max = 400, its_slack = 2;
+  PetscReal   advection = 1.0, shift = 0.1, tol = DEFAULT_CHECK_TOL;
+  PetscBool   transpose_solve = PETSC_FALSE, rebuild = PETSC_FALSE;
+
+  PetscCall(PetscInitialize(&argc, &args, (char *)0, help));
+
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-n_pairs", &n_pairs, NULL));
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-explicit_max", &explicit_max, NULL));
+  PetscCall(PetscOptionsGetReal(NULL, NULL, "-advection", &advection, NULL));
+  PetscCall(PetscOptionsGetReal(NULL, NULL, "-check_tol", &tol, NULL));
+  PetscCall(PetscOptionsGetBool(NULL, NULL, "-transpose_solve", &transpose_solve, NULL));
+  PetscCall(PetscOptionsGetInt(NULL, NULL, "-its_slack", &its_slack, NULL));
+  PetscCall(PetscOptionsGetBool(NULL, NULL, "-rebuild", &rebuild, NULL));
+
+  // Register the PFLARE types
+  PCRegister_PFLARE();
+
+  PetscCall(BuildOperator(n, advection, shift, &A));
+
+  // Seeded so a failure is reproducible
+  PetscCall(PetscRandomCreate(PETSC_COMM_WORLD, &rand));
+  PetscCall(PetscRandomSetFromOptions(rand));
+  PetscCall(PetscRandomSetSeed(rand, 314159));
+  PetscCall(PetscRandomSeed(rand));
+
+  PetscCall(PCCreate(PETSC_COMM_WORLD, &pc));
+  PetscCall(PCSetType(pc, PCPFLAREINV));
+  PetscCall(PCSetOperators(pc, A, A));
+  PetscCall(PCSetFromOptions(pc));
+  PetscCall(PCSetUp(pc));
+
+  // The second and later pairs also cover the transposed twin being cached
+  // rather than rebuilt on every apply
+  PetscCall(CheckTransposeIdentity(pc, A, rand, tol, n_pairs, "first setup"));
+  // 2n applies, so only on an operator small enough to make that cheap
+  if (n <= explicit_max) PetscCall(CheckTransposeExplicitly(pc, A, n, tol, "first setup"));
+
+  if (rebuild) {
+    // New values in the same nonzero pattern. This is what exercises the twin
+    // picking up refreshed coefficients and a refreshed diagonal, rather than
+    // holding on to the ones it was built with
+    PetscCall(SetOperatorValues(A, n, 2.0 * advection, shift));
+    PetscCall(PCSetOperators(pc, A, A));
+    PetscCall(PCSetUp(pc));
+    PetscCall(CheckTransposeIdentity(pc, A, rand, tol, n_pairs, "after rebuild"));
+    if (n <= explicit_max) PetscCall(CheckTransposeExplicitly(pc, A, n, tol, "after rebuild"));
+  }
+
+  PetscCall(PCDestroy(&pc));
+
+  if (transpose_solve) PetscCall(CheckTransposeSolve(A, its_slack));
+
+  PetscCall(PetscRandomDestroy(&rand));
+  PetscCall(MatDestroy(&A));
+  PetscCall(PetscFinalize());
+  return 0;
+}

--- a/tests/shell_block_apply.c
+++ b/tests/shell_block_apply.c
@@ -221,8 +221,6 @@ int main(int argc, char **args)
 
   PetscFunctionBeginUser;
   PetscCall(PetscInitialize(&argc, &args, (char *)0, help));
-  // We call PFLARE fortran routines directly below, so this has to have been called
-  PetscCall(PetscInitializeFortran());
 
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-n", &n, NULL));
   PetscCall(PetscOptionsGetInt(NULL, NULL, "-nrhs", &nrhs, NULL));


### PR DESCRIPTION
`PCPFLAREINV` had no transposed apply, so `KSPSolveTranspose` and anything else needing `B^T` failed on it. This adds one that applies the **exact transpose of what `PCApply` applies**, rather than a separately computed approximate inverse of `A^T` — that would be a different polynomial and so not an adjoint of the forward apply.

## Approach

The assembled inverses get this for free (aij and matdiagonal both transpose natively). For the matrix-free polynomials, all our coefficients are real, so `q(A)^T = q(A^T)` — the transposed apply is the *existing kernel run against a transposed operator*, and `MatCreateTranspose` gives us that virtually, for no memory and no assembly. `petsc_horner`, `petsc_newton` and the block kernels are untouched.

That also covers the right diagonally scaled variants, which is less obvious. Using `D⁻¹(AᵀD⁻¹)ᵏ = (D⁻¹Aᵀ)ᵏD⁻¹`:

```
(q(D⁻¹A) D⁻¹)ᵀ = D⁻¹ q(Aᵀ D⁻¹) = q(D⁻¹Aᵀ) D⁻¹
```

and `diag(Aᵀ) = diag(A)`, so `D` is unchanged and the transpose has the identical shell structure with the matrix replaced by its transpose. **Note the inner operator this needs is `D⁻¹Aᵀ`, not `mat_scaled^T = AᵀD⁻¹`** — so it cannot come from putting a `MATOP_MULT_TRANSPOSE` on the existing inner matshell; the twin builds its own inner matshell around the transposed matrix instead.

So the matshells get a `MATOP_MULT_TRANSPOSE` that builds a **transposed twin** on demand: a second matshell carrying a `MATTRANSPOSEVIRTUAL` of the operator, registered with the same forward callback the original has. It is built lazily, so never doing a transposed apply costs nothing, and it borrows the coefficients, roots, diagonal and scratch vectors rather than copying them — it owns only the virtual transpose and one or two shells. Those borrowed pointers are refreshed on every apply, because the builders deallocate and reallocate the coefficients when a matshell is reused with fresh ones, and the diagonal is updated in place.

A side benefit of reusing the forward kernels: the zero-coefficient skip in the Horner loop is reproduced bit-identically, where a hand-written transposed kernel would have been a second copy of that logic to keep in sync.

`petsc_matvec_ida_neumann_poly_mf` moves from `neumann_poly` into `gmres_poly_apply` — the twin builder has to register it on the inner shell and `neumann_poly` comes after `gmres_poly_apply` in the dependency order. It is also where the other matshell callbacks already live.

`PCMatApplyTranspose` is deliberately not set, so PETSc falls back to applying `PCApplyTranspose` column by column, which is correct.

If a user supplies their own MatShell as the operator (explicitly supported — it is why `diag_scale_polys` is never turned on here) and it has no `MatMultTranspose`, there is a clear error rather than a failure several layers down.

## Testing

New `tests/pflareinv_apply_transpose.c`, self-contained, checking the transpose three ways on a **strongly nonsymmetric** operator — a symmetric one would pass no matter what the transposed apply did:

1. the bilinear identity `y·(Mx) == x·(Mᵀy)` over random vectors, cheap at any size
2. building `M` and `Mᵀ` out column by column and comparing **every entry**
3. `KSPSolveTranspose` having to converge in the same iteration count as the equivalent forward solve

(2) is the sharp one. A deliberately broken transposed apply showed up at only **0.2%** relative error in the bilinear identity — an approximate inverse of a diagonally dominant matrix is nearly symmetric, so contracting a whole matrix to one number is a weak test — but at order one in the entry-by-entry check. Correct, it reports ~1e-17.

On (3), left-preconditioned GMRES on the transposed system iterates on `MᵀAᵀ = (AM)ᵀ`, which has the spectrum of `AM`, ie the *right* preconditioned forward problem, so that is what the assertion compares against. Measured, the transposed solve tracks the forward one exactly:

| case | transposed | fwd right | fwd left |
|---|---|---|---|
| assembled newton | 59 | 60 | 59 |
| matrix-free newton | 22 | 22 | 22 |
| matrix-free newton, 2 ranks | 21 | 21 | 21 |
| matrix-free neumann, strong advection | 60 | 60 | 60 |

30 test invocations across all 9 inverse types × assembled/matrix-free, serial and 2-rank, plus rebuild cases that cover the twin picking up refreshed coefficients. They add ~18s to `make tests_short` (3m38s); each is ~0.5s, of which ~0.46s is PETSc debug-build startup.

`make check`, `make tests_short`, the new tests under `-mat_type aijkokkos -vec_type kokkos`, and `PFLARE_KOKKOS_DEBUG=1` all pass. `-malloc_dump -objects_dump` is clean on the matrix-free paths. No compile warnings, and no added Fortran line exceeds the 132-char CI limit.

Also drops a `PetscInitializeFortran` from `shell_block_apply`, which no other C driver needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
